### PR TITLE
Add Symfony 8 support and lazy handler/validator loading in CommandBus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,114 +1,153 @@
-# Lead core bundle
+# leads/core
 
-Lead core bundle for the Symfony Framework
+Shared core bundle for Leads projects built on the Symfony Framework. It provides a lightweight command bus, DBAL-based pagination, API request validation helpers and base controller utilities.
+
+## Requirements
+
+- PHP >= 8.3
+- Symfony 7.2+ or 8.x (the package resolves to Symfony 8.x on PHP >= 8.4)
+- Doctrine DBAL ^4.0 (used by the pagination component)
 
 ## Installation
-
-Install the latest version with
 
 ```bash
 composer require leads/core
 ```
-<details>
-<summary>CommandBus</summary>
+
+Register the bundle in `config/bundles.php` (done automatically if you use Symfony Flex):
 
 ```php
-<?php
+return [
+    // ...
+    Leads\Core\LeadsCoreBundle::class => ['all' => true],
+];
+```
 
-declare(strict_types=1);
+## Command bus
 
+A minimal synchronous command bus. Handlers and validators are discovered by PHP attributes and wired at container compile time; they are instantiated lazily through a service locator — only when their command is actually dispatched.
+
+### 1. Define a command
+
+```php
 use Leads\Core\CommandBus\CommandInterface;
 
-final readonly class ExampleCommand implements CommandInterface
+final readonly class CreateOrderCommand implements CommandInterface
 {
-}
-```
-```php
-<?php
-
-declare(strict_types=1);
-
-use Leads\Core\CommandBus\CommandValidatorInterface;
-use Leads\Core\CommandBus\CommandInterface;
-use Leads\Core\CommandBus\AsCommandValidator;
-
-/**
- * @implements CommandValidatorInterface<ExampleCommand>
- */
- #[AsCommandValidator(commandClass: ExampleCommand::class)]
-final readonly class Validator1 implements CommandValidatorInterface 
-{
-    /**
-     * @param ExampleCommand $command
-     */
-    public function validate(CommandInterface $command): void
-    {
-        // validate command
-    }   
-}
-```
-```php
-<?php
-
-declare(strict_types=1);
-
-use Leads\Core\CommandBus\HandlerInterface;
-use Leads\Core\CommandBus\AsCommandHandler;
-
-/**
- * @implements HandlerInterface<ExampleCommand>
- */
-#[AsCommandHandler(commandClass: ExampleCommand::class)]
-class ExampleHandler implements HandlerInterface
-{
-    /**
-     * @param ExampleCommand $command
-     */
-    public function handle(CommandInterface $command)
-    {
-        // handle command
+    public function __construct(
+        public string $customerId,
+        public int $amount,
+    ) {
     }
 }
 ```
 
-</details>
+### 2. Define a handler
 
-<br>
-
-<details>
-<summary>Exception</summary>
-<ul>
-    <li>Leads\Core\Exception\EntityNotFoundException.php</li>
-</ul>
-</details>
-
-<br>
-
-<details>
-<summary>Pagination</summary>
+Exactly one handler per command, marked with `#[AsCommandHandler]`:
 
 ```php
-<?php
+use Leads\Core\CommandBus\AsCommandHandler;
+use Leads\Core\CommandBus\CommandInterface;
+use Leads\Core\CommandBus\HandlerInterface;
 
-declare(strict_types=1);
+/**
+ * @implements HandlerInterface<CreateOrderCommand>
+ */
+#[AsCommandHandler(commandClass: CreateOrderCommand::class)]
+final readonly class CreateOrderHandler implements HandlerInterface
+{
+    /**
+     * @param CreateOrderCommand $command
+     */
+    public function handle(CommandInterface $command)
+    {
+        // create the order, return whatever the caller needs (e.g. an id)
+    }
+}
+```
 
-use Leads\Core\Pagination\Pagination;
-use Leads\Core\Pagination\DBALPagination;
+### 3. Define validators (optional)
+
+Any number of validators per command, marked with `#[AsCommandValidator]`. All matching validators run before the handler; a validator reports failure by throwing `CommandValidatorException`:
+
+```php
+use Leads\Core\CommandBus\AsCommandValidator;
+use Leads\Core\CommandBus\CommandInterface;
+use Leads\Core\CommandBus\CommandValidatorException;
+use Leads\Core\CommandBus\CommandValidatorInterface;
+
+/**
+ * @implements CommandValidatorInterface<CreateOrderCommand>
+ */
+#[AsCommandValidator(commandClass: CreateOrderCommand::class)]
+final readonly class CreateOrderAmountValidator implements CommandValidatorInterface
+{
+    /**
+     * @param CreateOrderCommand $command
+     */
+    public function validate(CommandInterface $command): void
+    {
+        if ($command->amount <= 0) {
+            throw new CommandValidatorException('Amount must be positive.');
+        }
+    }
+}
+```
+
+### 4. Dispatch
+
+Inject `CommandBus` and call `handle()`:
+
+```php
+use Leads\Core\CommandBus\CommandBus;
+
+final readonly class OrderService
+{
+    public function __construct(
+        private CommandBus $commandBus,
+    ) {
+    }
+
+    public function createOrder(string $customerId, int $amount): mixed
+    {
+        return $this->commandBus->handle(new CreateOrderCommand($customerId, $amount));
+    }
+}
+```
+
+Exceptions thrown by `CommandBus::handle()`:
+
+- `Leads\Core\CommandBus\CommandValidatorException` — a validator rejected the command (default code 400)
+- `Leads\Core\CommandBus\HandlerNotFoundException` — no handler is registered for the command class
+
+## Pagination
+
+Page-based pagination over a Doctrine DBAL `QueryBuilder`. The `Leads\Core\Pagination` namespace is excluded from container autowiring — instantiate the classes manually:
+
+```php
 use Doctrine\DBAL\Connection;
+use Leads\Core\Pagination\DBALPagination;
+use Leads\Core\Pagination\DTO\ListResponseDTO;
+use Leads\Core\Pagination\Pagination;
 
-class ExampleRepository
+final readonly class OrderRepository
 {
     public function __construct(
         private Connection $connection,
     ) {
     }
-    
-    public function find(int $page, int $perPage)
+
+    public function findPaginated(int $page, int $perPage): ListResponseDTO
     {
-        // create Doctrine\DBAL\Query\QueryBuilder $qb
-        $pagination = (new Pagination(
-            page: 1,
-            perPage: 10,
+        $qb = $this->connection->createQueryBuilder()
+            ->select('id', 'customer_id', 'amount')
+            ->from('orders')
+            ->orderBy('id', 'DESC');
+
+        return (new Pagination(
+            page: $page,
+            perPage: $perPage,
             pagination: new DBALPagination(
                 connection: $this->connection,
                 qb: $qb,
@@ -116,17 +155,56 @@ class ExampleRepository
         ))->paginate();
     }
 }
-
 ```
 
-</details>
+`paginate()` returns a `ListResponseDTO`:
 
-<br>
+- `items` — the rows for the requested page (`fetchAllAssociative()` result)
+- `pagination` — a `PaginationDTO` with `count` (items on this page), `total` (total rows), `page`, `perPage` and `pages` (total page count)
 
-<details>
-<summary>BaseAction</summary>
+The total is computed by wrapping your query in a `COUNT(*)` subquery (with `ORDER BY` stripped), so it stays correct for queries with `GROUP BY` or `DISTINCT`. `Pagination` throws `\InvalidArgumentException` if `page` or `perPage` is less than 1.
 
-    Adds a basic function for validating request api and template responses.
-    See methods of the BaseAction.php class
+To paginate a different data source, implement `Leads\Core\Pagination\PaginationInterface` (`getItems(int $offset, int $limit): array` and `getTotal(): int`) and pass it instead of `DBALPagination`.
 
-</details>
+## API validation and base controller
+
+`ApiValidator` wraps the Symfony Validator: it validates an object against its constraint attributes and throws `ApiValidationException` if there are violations. The exception exposes the violations as `getErrors()` — a list of `['property' => ..., 'message' => ...]` pairs, also JSON-encoded into the exception message.
+
+Controllers can extend `BaseAction` to get validation plus JSON response helpers:
+
+```php
+use Leads\Core\Action\BaseAction;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+final class CreateOrderAction extends BaseAction
+{
+    public function __invoke(CreateOrderRequest $request): JsonResponse
+    {
+        $this->validate($request); // throws ApiValidationException on violations
+
+        $id = /* ... */;
+
+        return $this->create201Response($id); // {"id": "..."}
+    }
+}
+```
+
+Available response helpers:
+
+- `create200Response(array $data)` — 200 with a JSON body
+- `create201Response(string $id)` — 201 with `{"id": ...}`
+- `create201ContentResponse(array $response)` — 201 with a custom body
+- `create201EmptyResponse()` — 201 with an empty body
+- `create204Response()` — 204
+- `create400Response(string $message)` — 400 with a message
+- `createCustomResponse(array $data, int $status)` — any status
+
+`ApiValidatorInterface` is autowired to `ApiValidator` by the bundle; you can also inject it directly into your own services.
+
+## Exceptions
+
+- `Leads\Core\Exception\EntityNotFoundException` — a `\LogicException` with message `Entity not found` and code 404, for signalling missing entities from repositories/handlers.
+
+## License
+
+MIT

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "version": "0.0.14",
+    "version": "0.0.15",
     "authors": [
         {
             "name": "Maxim Lahoiski",
@@ -15,10 +15,13 @@
     "require": {
         "php": ">=8.3",
         "doctrine/dbal": "^4.0",
-        "symfony/dependency-injection": "^7.2",
-        "symfony/http-kernel": "^7.2",
-        "symfony/config": "^7.2",
-        "symfony/validator": "^7.2"
+        "psr/container": "^2.0",
+        "symfony/dependency-injection": "^7.2 || ^8.0",
+        "symfony/http-foundation": "^7.2 || ^8.0",
+        "symfony/http-kernel": "^7.2 || ^8.0",
+        "symfony/config": "^7.2 || ^8.0",
+        "symfony/validator": "^7.2 || ^8.0",
+        "symfony/yaml": "^7.2 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/CommandBus/CommandBus.php
+++ b/src/CommandBus/CommandBus.php
@@ -4,23 +4,29 @@ declare(strict_types=1);
 
 namespace Leads\Core\CommandBus;
 
-final class CommandBus
+use Psr\Container\ContainerInterface;
+
+final readonly class CommandBus
 {
+    /**
+     * @param ContainerInterface $handlers service locator keyed by command class-string
+     */
     public function __construct(
-        /** @var array<class-string<CommandInterface>, HandlerInterface> */
-        private array $commandsMap,
+        private ContainerInterface $handlers,
         private CommandValidator $commandValidator,
     ) {
     }
 
-    /**
-     * @psalm-suppress MissingReturnType
-     */
-    public function handle(CommandInterface $command)
+    public function handle(CommandInterface $command): mixed
     {
-        $handler = $this->commandsMap[$command::class] ?? throw new \LogicException('Handler not found.');
-
         $this->commandValidator->validate($command);
+
+        if (!$this->handlers->has($command::class)) {
+            throw new HandlerNotFoundException($command::class);
+        }
+
+        /** @var HandlerInterface $handler */
+        $handler = $this->handlers->get($command::class);
 
         return $handler->handle($command);
     }

--- a/src/CommandBus/CommandValidator.php
+++ b/src/CommandBus/CommandValidator.php
@@ -4,18 +4,25 @@ declare(strict_types=1);
 
 namespace Leads\Core\CommandBus;
 
+use Psr\Container\ContainerInterface;
+
 final readonly class CommandValidator
 {
+    /**
+     * @param ContainerInterface $validators service locator keyed by validator service id
+     * @param array<class-string<CommandInterface>, list<string>> $validatorsMap command class-string => list of validator service ids
+     */
     public function __construct(
-        /** @var array<class-string<CommandInterface>, CommandValidatorInterface[]> */
+        private ContainerInterface $validators,
         private array $validatorsMap,
     ) {
     }
 
     public function validate(CommandInterface $command): void
     {
-        $validators = $this->validatorsMap[$command::class] ?? [];
-        foreach ($validators as $validator) {
+        foreach ($this->validatorsMap[$command::class] ?? [] as $id) {
+            /** @var CommandValidatorInterface $validator */
+            $validator = $this->validators->get($id);
             $validator->validate($command);
         }
     }

--- a/src/CommandBus/HandlerNotFoundException.php
+++ b/src/CommandBus/HandlerNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\CommandBus;
+
+final class HandlerNotFoundException extends \LogicException
+{
+    /**
+     * @param class-string<CommandInterface> $commandClass
+     */
+    public function __construct(string $commandClass)
+    {
+        parent::__construct(sprintf('No handler registered for command "%s".', $commandClass));
+    }
+}

--- a/src/DependencyInjection/Compiler/CommandBusCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CommandBusCompilerPass.php
@@ -8,6 +8,7 @@ use Leads\Core\CommandBus\AsCommandHandler;
 use Leads\Core\CommandBus\CommandBus;
 use Leads\Core\CommandBus\CommandValidator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -35,9 +36,11 @@ final class CommandBusCompilerPass implements CompilerPassInterface
             $commandsMap[$attr->commandClass] = new Reference($id);
         }
 
+        $handlers = ServiceLocatorTagPass::register($container, $commandsMap, CommandBus::class);
+
         $container
             ->register(CommandBus::class, CommandBus::class)
-            ->setArguments([$commandsMap, new Reference(CommandValidator::class)])
+            ->setArguments([$handlers, new Reference(CommandValidator::class)])
             ->setPublic(true);
     }
 }

--- a/src/DependencyInjection/Compiler/CommandValidatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/CommandValidatorCompilerPass.php
@@ -7,6 +7,7 @@ namespace Leads\Core\DependencyInjection\Compiler;
 use Leads\Core\CommandBus\AsCommandValidator;
 use Leads\Core\CommandBus\CommandValidator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -15,6 +16,7 @@ final class CommandValidatorCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container): void
     {
         $validatorsMap = [];
+        $locatorMap = [];
 
         foreach ($container->findTaggedServiceIds('leads-core.use-case.validator') as $id => $definition) {
             $definition = $container->getDefinition($id);
@@ -31,12 +33,15 @@ final class CommandValidatorCompilerPass implements CompilerPassInterface
 
             /** @var AsCommandValidator $attr */
             $attr = $attributes[0]->newInstance();
-            $validatorsMap[$attr->commandClass][] = new Reference($id);
+            $validatorsMap[$attr->commandClass][] = $id;
+            $locatorMap[$id] = new Reference($id);
         }
+
+        $validators = ServiceLocatorTagPass::register($container, $locatorMap, CommandValidator::class);
 
         $container
             ->register(CommandValidator::class, CommandValidator::class)
-            ->setArguments([$validatorsMap])
+            ->setArguments([$validators, $validatorsMap])
             ->setPublic(true);
     }
 }


### PR DESCRIPTION
  CommandBus:
  - Load command handlers and validators lazily via service locators (ServiceLocatorTagPass) instead of eagerly injecting all instances
  - Throw dedicated HandlerNotFoundException instead of a bare LogicException when no handler is registered for a command
  - Add explicit `mixed` return type to CommandBus::handle()

  Compatibility:
  - Allow Symfony 8.0/8.1: widen symfony/* constraints to ^7.2 || ^8.0
  - Declare directly used dependencies that were previously only transitive: symfony/http-foundation, symfony/yaml, psr/container
  - Bump package version to 0.0.15