### PR TITLE
- Describe the Leads\Core\Exception namespace contract: RuntimeExcept…

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,18 @@ Available response helpers:
 
 ## Exceptions
 
-- `Leads\Core\Exception\EntityNotFoundException` — a `\LogicException` with message `Entity not found` and code 404, for signalling missing entities from repositories/handlers.
+The `Leads\Core\Exception` namespace provides ready-to-use domain exceptions. All of them extend `\RuntimeException` and carry an HTTP-like status code in `getCode()`, so an exception listener can map them to responses directly. Each constructor accepts an optional custom message, code override and `previous` throwable:
+
+- `Leads\Core\Exception\EntityNotFoundException` — `Entity not found.`, code 404; for missing entities in repositories/handlers
+- `Leads\Core\Exception\UserNotFoundException` — `User not found.`, code 404
+- `Leads\Core\Exception\AccessDeniedException` — `Access Denied.`, code 403
+
+```php
+use Leads\Core\Exception\EntityNotFoundException;
+
+$order = $repository->find($id)
+    ?? throw new EntityNotFoundException(sprintf('Order "%s" not found.', $id));
+```
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "version": "0.0.15",
+    "version": "0.0.16",
     "authors": [
         {
             "name": "Maxim Lahoiski",

--- a/src/Exception/AccessDeniedException.php
+++ b/src/Exception/AccessDeniedException.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Leads\Core\Exception;
 
-class EntityNotFoundException extends \RuntimeException
+class AccessDeniedException extends \RuntimeException
 {
     public function __construct(
-        string $message = 'Entity not found.',
-        int $code = 404,
+        string $message = 'Access Denied.',
+        int $code = 403,
         ?\Throwable $previous = null,
     ) {
         parent::__construct(message: $message, code: $code, previous: $previous);

--- a/src/Exception/UserNotFoundException.php
+++ b/src/Exception/UserNotFoundException.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Leads\Core\Exception;
 
-class EntityNotFoundException extends \RuntimeException
+class UserNotFoundException extends \RuntimeException
 {
     public function __construct(
-        string $message = 'Entity not found.',
+        string $message = 'User not found.',
         int $code = 404,
         ?\Throwable $previous = null,
     ) {


### PR DESCRIPTION
- Describe the Leads\Core\Exception namespace contract: RuntimeException base,
  HTTP-like code in getCode(), customizable message/code/previous
- List EntityNotFoundException (404), UserNotFoundException (404)
  and AccessDeniedException (403) with their defaults
- Add a usage example with a custom message