### PR TITLE
Add ClickHousePagination with optional smi2/phpclickhouse dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,34 @@ The total is computed by wrapping your query in a `COUNT(*)` subquery (with `ORD
 
 To paginate a different data source, implement `Leads\Core\Pagination\PaginationInterface` (`getItems(int $offset, int $limit): array` and `getTotal(): int`) and pass it instead of `DBALPagination`.
 
+### ClickHouse
+
+`ClickHousePagination` runs the same DBAL `QueryBuilder`-built query against ClickHouse via the `smi2/phpclickhouse` client. The package is an optional dependency — install it in your project first:
+
+```bash
+composer require smi2/phpclickhouse
+```
+
+```php
+use ClickHouseDB\Client;
+use Leads\Core\Pagination\ClickHousePagination;
+use Leads\Core\Pagination\Pagination;
+
+return (new Pagination(
+    page: $page,
+    perPage: $perPage,
+    pagination: new ClickHousePagination(
+        client: $client, // ClickHouseDB\Client
+        qb: $qb,
+    ),
+))->paginate();
+```
+
+Constraints:
+
+- The `QueryBuilder` must use **named parameters** (`:name`) — positional `?` placeholders are not substituted by the ClickHouse client.
+- The SQL (including `LIMIT`/`OFFSET` syntax and identifier quoting) is rendered by the DBAL platform of the connection the `QueryBuilder` was created from, so use a connection whose platform produces ClickHouse-compatible SQL (MySQL and PostgreSQL platforms are fine).
+
 ## API validation and base controller
 
 `ApiValidator` wraps the Symfony Validator: it validates an object against its constraint attributes and throws `ApiValidationException` if there are violations. The exception exposes the violations as `getErrors()` — a list of `['property' => ..., 'message' => ...]` pairs, also JSON-encoded into the exception message.

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,12 @@
         "symfony/validator": "^7.2 || ^8.0",
         "symfony/yaml": "^7.2 || ^8.0"
     },
+    "require-dev": {
+        "smi2/phpclickhouse": "^1.6 || ^1.26"
+    },
+    "suggest": {
+        "smi2/phpclickhouse": "Required to use Leads\\Core\\Pagination\\ClickHousePagination (^1.6 || ^1.26)"
+    },
     "autoload": {
         "psr-4": {
             "Leads\\Core\\": "src/"

--- a/src/Pagination/ClickHousePagination.php
+++ b/src/Pagination/ClickHousePagination.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Pagination;
+
+use ClickHouseDB\Client;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * Requires the optional smi2/phpclickhouse package (`composer require smi2/phpclickhouse`).
+ *
+ * The QueryBuilder must use named parameters (`:name`) — positional `?`
+ * placeholders are not substituted by the ClickHouse client.
+ */
+final readonly class ClickHousePagination implements PaginationInterface
+{
+    public function __construct(
+        private Client $client,
+        private QueryBuilder $qb,
+    ) {
+    }
+
+    public function getItems(int $offset, int $limit): array
+    {
+        $targetQb = (clone $this->qb)
+            ->setFirstResult($offset)
+            ->setMaxResults($limit);
+
+        return $this->client
+            ->select($targetQb->getSQL(), $targetQb->getParameters())
+            ->rows();
+    }
+
+    public function getTotal(): int
+    {
+        $targetQb = clone $this->qb;
+        $targetQb->resetOrderBy();
+
+        return (int)$this->client
+            ->select('SELECT count() AS total FROM (' . $targetQb->getSQL() . ')', $targetQb->getParameters())
+            ->fetchOne('total');
+    }
+}

--- a/src/Pagination/DTO/ListResponseDTO.php
+++ b/src/Pagination/DTO/ListResponseDTO.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Leads\Core\Pagination\DTO;
 
-class ListResponseDTO
+final readonly class ListResponseDTO
 {
     public function __construct(
         public array $items,


### PR DESCRIPTION
- Add ClickHousePagination implementing PaginationInterface: renders a DBAL QueryBuilder to SQL and executes it via the smi2/phpclickhouse client; total is computed with count() over the subquery with ORDER BY stripped
- Keep smi2/phpclickhouse out of require: move it to suggest and require-dev (^1.6 || ^1.26) so consumers install the client only when they use ClickHouse pagination
- Make ListResponseDTO final readonly, in line with the other Pagination classes (BC break for consumers extending it)
- Document ClickHousePagination in README: installation, usage, named-parameters-only and SQL platform compatibility constraints