### PR TITLE
Add HTTP Payload mapping component

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /tests             export-ignore
+/phpunit.xml.dist  export-ignore
 /psalm.xml         export-ignore
 /rector.php        export-ignore
 /.php-cs-fixer.php export-ignore

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # leads/core
 
-Shared core bundle for Leads projects built on the Symfony Framework. It provides DBAL-based pagination, API request validation helpers and base controller utilities.
+Shared core bundle for Leads projects built on the Symfony Framework. It provides HTTP payload mapping into request DTOs, DBAL-based pagination, API request validation helpers and base controller utilities.
 
 ## Requirements
 
-- PHP >= 8.3
-- Symfony 7.2+ or 8.x (the package resolves to Symfony 8.x on PHP >= 8.4)
+- PHP >= 8.4
+- Symfony 8.1+
 - Doctrine DBAL ^4.0 (used by the pagination component)
 
 ## Installation
@@ -22,6 +22,60 @@ return [
     Leads\Core\LeadsCoreBundle::class => ['all' => true],
 ];
 ```
+
+## HTTP payload mapping
+
+`Leads\Core\Payload` maps an HTTP request into an immutable request DTO declared with attributes — no serializer, no per-endpoint glue code. Put `#[Payload]` on a controller argument and the bundle's value resolver builds, casts and validates the DTO:
+
+```php
+use Leads\Core\Payload\Attribute\Clamp;
+use Leads\Core\Payload\Attribute\FromHeader;
+use Leads\Core\Payload\Attribute\FromPath;
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\Payload;
+
+final readonly class ListOrdersRequest
+{
+    public function __construct(
+        #[FromQuery]
+        #[Clamp(1, 100)]
+        public int $limit = 20,
+        #[FromQuery]
+        public ?\DateTimeImmutable $fromDate = null,
+        #[FromPath]
+        public string $projectId,
+        #[FromHeader('X-Request-Source')]
+        public ?string $requestSource = null,
+    ) {
+    }
+}
+
+final class ListOrdersAction
+{
+    public function __invoke(#[Payload] ListOrdersRequest $request): JsonResponse
+    {
+        // $request is fully cast and validated here
+    }
+}
+```
+
+Every constructor parameter declares its source: `#[FromBody]`, `#[FromQuery]`, `#[FromPath]` or `#[FromHeader('Name')]`. Values are cast to the parameter type (scalars, `\DateTimeImmutable`, backed enums, nested DTOs, collections via a `@param list<...>` docblock) and then run through the Symfony Validator (constraint attributes on the DTO). Additional behavior attributes:
+
+- `#[HttpPayload(groups: [...], maxBodyBytes: ...)]` (class level) — validation groups and body size limit
+- `#[Clamp(min, max)]` — clamp an int into a range
+- `#[FallbackTo(value)]` — value to use when casting fails (except type mismatches)
+- `#[Split(separator: ',')]` — split a query string into a scalar list
+- `#[MaxItems(n)]` — collection size limit (default 1000)
+- `#[FreeForm]` — accept an arbitrary array structure as-is
+- `#[Normalized]` — case-insensitive enum matching
+
+Misconfiguration (missing source attribute, unsupported type, nested constraints without `#[Assert\Valid]`, …) fails fast with a `\LogicException` when the plan is compiled — not at request time.
+
+Errors are reported per field with JSON-pointer-style paths (`body/items/0/quantity`, `query/limit`): casting failures throw a 400, validator violations a 422, plus 413 for oversized and 400 for malformed bodies. All of these implement `Leads\Core\Payload\Error\HttpProblemException`, and the bundled `PayloadExceptionListener` turns them into RFC 9457 `application/problem+json` responses automatically. `StateConflictException` (409) is available for domain-level conflicts in the same format.
+
+The component is extensible from the consuming project: implement `Leads\Core\Payload\Cast\ValueCaster` or `Leads\Core\Payload\Source\ValueSource` in your application and autoconfiguration tags it (`leads_core.payload.caster` / `leads_core.payload.source`) — no configuration needed.
+
+You can also call the mapper directly instead of using the resolver: inject `Leads\Core\Payload\PayloadMapper` and call `map(MyRequest::class, $request)`.
 
 ## Pagination
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "version": "1.1.0",
+    "version": "1.2.0",
     "authors": [
         {
             "name": "Maxim Lahoiski",
@@ -15,17 +15,23 @@
     "require": {
         "php": ">=8.4",
         "doctrine/dbal": "^4.0",
+        "phpdocumentor/reflection-docblock": "^6.0",
+        "psr/log": "^3.0",
         "symfony/dependency-injection": "^8.1",
+        "symfony/event-dispatcher": "^8.1",
         "symfony/http-foundation": "^8.1",
         "symfony/http-kernel": "^8.1",
         "symfony/config": "^8.1",
+        "symfony/type-info": "^8.1",
         "symfony/validator": "^8.1",
         "symfony/yaml": "^8.1"
     },
     "require-dev": {
         "smi2/phpclickhouse": "^1.6 || ^1.26",
         "friendsofphp/php-cs-fixer": "^3.95",
+        "phpunit/phpunit": "^13.0",
         "squizlabs/php_codesniffer": "^4.0",
+        "symfony/framework-bundle": "^8.1",
         "vimeo/psalm": "^6.16",
         "rector/rector": "^2.6"
     },
@@ -49,6 +55,7 @@
         "rector": "vendor/bin/rector process --dry-run",
         "rector-fix": "vendor/bin/rector process",
         "code-sniffer": "vendor/bin/phpcs -s",
-        "code-sniffer-fix": "vendor/bin/phpcbf"
+        "code-sniffer-fix": "vendor/bin/phpcbf",
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory="var/.phpunit.cache"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
+>
+    <php>
+        <ini name="display_errors" value="1"/>
+        <ini name="error_reporting" value="-1"/>
+    </php>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,11 @@
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <directory name="src/Payload"/>
+            </errorLevel>
+        </MixedAssignment>
         <ClassMustBeFinal>
             <errorLevel type="suppress">
                 <directory name="src"/>

--- a/src/DependencyInjection/LeadsCoreExtension.php
+++ b/src/DependencyInjection/LeadsCoreExtension.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Leads\Core\DependencyInjection;
 
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Source\ValueSource;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\Extension;
@@ -13,6 +15,11 @@ final class LeadsCoreExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container): void
     {
+        $container->registerForAutoconfiguration(ValueSource::class)
+            ->addTag('leads_core.payload.source');
+        $container->registerForAutoconfiguration(ValueCaster::class)
+            ->addTag('leads_core.payload.caster');
+
         $loader = new YamlFileLoader(
             $container,
             new FileLocator(__DIR__ . '/../Resources/config'),

--- a/src/Payload/Attribute/Clamp.php
+++ b/src/Payload/Attribute/Clamp.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Ограничение целого значения диапазоном [min, max] вместо отклонения.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class Clamp
+{
+    public function __construct(
+        public int $min,
+        public int $max,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/FallbackTo.php
+++ b/src/Payload/Attribute/FallbackTo.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Значение по умолчанию при НЕ-типовой ошибке каста (enum.unknown и т.п.).
+ *
+ * Для enum принимает кейс, а не строку: опечатка становится ошибкой компиляции.
+ * Типовые ошибки (type.*) fallback не восстанавливает — сломанный клиент получает 400.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FallbackTo
+{
+    public function __construct(
+        public \BackedEnum|string|int|float|bool|null $value,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/FreeForm.php
+++ b/src/Payload/Attribute/FreeForm.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Произвольная JSON-структура без схемы: значение проходит в DTO как есть.
+ *
+ * Явный опт-ин, а не докблок: TypeInfo не отличает отсутствие докблока
+ * от "array<string, mixed>" — оба резолвятся в mixed. Защита от DoS —
+ * байтовый и глубинный лимиты RequestContext; констрейнты валидатора
+ * на свойстве работают как обычно.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FreeForm
+{
+}

--- a/src/Payload/Attribute/FromBody.php
+++ b/src/Payload/Attribute/FromBody.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FromBody
+{
+    /**
+     * @param ?string $key ключ в теле; null — имя свойства
+     */
+    public function __construct(
+        public ?string $key = null,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/FromHeader.php
+++ b/src/Payload/Attribute/FromHeader.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FromHeader
+{
+    /**
+     * Имя заголовка обязательно: '#[FromHeader] $xRequestSource' скрывал бы реальное имя.
+     * Отсутствие имени — ошибка компиляции, а не построения плана.
+     */
+    public function __construct(
+        public string $name,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/FromPath.php
+++ b/src/Payload/Attribute/FromPath.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FromPath
+{
+    /**
+     * @param ?string $key имя параметра роута; null — имя свойства
+     */
+    public function __construct(
+        public ?string $key = null,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/FromQuery.php
+++ b/src/Payload/Attribute/FromQuery.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class FromQuery
+{
+    /**
+     * @param ?string $key имя query-параметра; null — имя свойства
+     */
+    public function __construct(
+        public ?string $key = null,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/HttpPayload.php
+++ b/src/Payload/Attribute/HttpPayload.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Настройки DTO целиком. Отсутствие атрибута эквивалентно дефолтам.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class HttpPayload
+{
+    public const int DEFAULT_MAX_BODY_BYTES = 1_048_576;
+
+    /**
+     * @param ?list<string> $groups группы валидации; null — дефолтные
+     */
+    public function __construct(
+        public ?array $groups = null,
+        public int $maxBodyBytes = self::DEFAULT_MAX_BODY_BYTES,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/MaxItems.php
+++ b/src/Payload/Attribute/MaxItems.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Переопределение лимита элементов коллекции (по умолчанию 1000).
+ * Это ограничитель нагрузки, а не политика прощения формата: превышение — всегда 400.
+ * На #[FreeForm] не действует по дизайну — там границы задают лимиты байт и глубины тела.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class MaxItems
+{
+    public function __construct(
+        public int $max,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/Normalized.php
+++ b/src/Payload/Attribute/Normalized.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Регистронезависимое сопоставление значения с кейсами enum.
+ *
+ * Единственная политика, реализованная флагом внутри кастера (EnumCaster), а не декоратором:
+ * сопоставление требует доступа к $enum::cases(), которых декоратор не видит.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class Normalized
+{
+}

--- a/src/Payload/Attribute/Payload.php
+++ b/src/Payload/Attribute/Payload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Помечает аргумент контроллера для маппинга через PayloadMapper.
+ *
+ * Имя намеренно не MapPayload — чтобы не путалось с симфонийским MapRequestPayload.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class Payload
+{
+    /**
+     * @param ?list<string> $groups группы валидации; null — дефолтные
+     */
+    public function __construct(
+        public ?array $groups = null,
+    ) {
+    }
+}

--- a/src/Payload/Attribute/Split.php
+++ b/src/Payload/Attribute/Split.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Attribute;
+
+/**
+ * Коллекция скаляров, приходящая строкой с разделителем ('?ids=a,b,c').
+ * Настоящий список ('?ids[]=a&ids[]=b') проходит без изменений — оба синтаксиса живут параллельно.
+ */
+#[\Attribute(\Attribute::TARGET_PROPERTY | \Attribute::TARGET_PARAMETER)]
+final readonly class Split
+{
+    public function __construct(
+        public string $separator = ',',
+    ) {
+    }
+}

--- a/src/Payload/Cast/BoolCaster.php
+++ b/src/Payload/Cast/BoolCaster.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final class BoolCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->type === 'bool';
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_bool($value)) {
+            return Result::ok($value);
+        }
+
+        if (\is_string($value) || \is_int($value)) {
+            $filtered = filter_var($value, \FILTER_VALIDATE_BOOLEAN, \FILTER_NULL_ON_FAILURE);
+            if ($filtered !== null) {
+                return Result::ok($filtered);
+            }
+        }
+
+        return Result::fail(new Reason('type.bool', 'Expected a boolean.'));
+    }
+}

--- a/src/Payload/Cast/CasterRegistry.php
+++ b/src/Payload/Cast/CasterRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+
+/**
+ * Реестр кастеров. Хранит ленивый iterable (tagged_iterator) и НЕ материализует его
+ * в конструкторе — это разрывает цикл PlanFactory → CasterRegistry → NestedObjectCaster →
+ * PlanFactory при построении контейнера.
+ */
+final readonly class CasterRegistry
+{
+    /**
+     * @param iterable<ValueCaster> $casters
+     */
+    public function __construct(
+        private iterable $casters,
+    ) {
+    }
+
+    public function resolve(PropertyPlan $plan): ?ValueCaster
+    {
+        foreach ($this->casters as $caster) {
+            if ($caster->supports($plan)) {
+                return $caster;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Payload/Cast/CollectionCaster.php
+++ b/src/Payload/Cast/CollectionCaster.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final readonly class CollectionCaster implements ValueCaster
+{
+    public function __construct(
+        private PlanFactory $plans,
+        private ObjectAssembler $assembler,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->itemClass !== null;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_array($value) === false || array_is_list($value) === false) {
+            return Result::fail(new Reason('type.collection', 'Expected a list.'));
+        }
+
+        // Жёсткий предел здесь, а не Assert\Count: Count сработал бы после конструирования —
+        // сто тысяч элементов это сто тысяч объектов в памяти до первой проверки.
+        if (\count($value) > $plan->maxItems) {
+            return Result::fail(new Reason(
+                'collection.too_many',
+                sprintf('Too many items; at most %d allowed.', $plan->maxItems),
+                ['max' => $plan->maxItems],
+            ));
+        }
+
+        $itemClass = $plan->itemClass
+            ?? throw new \LogicException(sprintf('Plan for property %s has no item class.', $plan->name));
+
+        $childPlan = $this->plans->build($itemClass, nested: true);
+
+        $items = [];
+        $reasons = [];
+
+        foreach ($value as $index => $item) {
+            if (\is_array($item) === false) {
+                $reasons[] = new Reason('type.object', 'Expected an object.')->nest($index);
+
+                break;
+            }
+
+            $result = $this->assembler->assemble($childPlan, $item, $raw->depth + 1);
+
+            if ($result->isOk()) {
+                $items[] = $result->value();
+
+                continue;
+            }
+
+            foreach ($result->reasons() as $reason) {
+                $reasons[] = $reason->nest($index);
+            }
+
+            break;   // fail-fast, как и в ассемблере
+        }
+
+        if ($reasons !== []) {
+            return Result::fail(...$reasons);
+        }
+
+        return Result::ok($items);
+    }
+}

--- a/src/Payload/Cast/DateCaster.php
+++ b/src/Payload/Cast/DateCaster.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Даты и datetime в одном кастере: у обоих объявленный тип \DateTimeImmutable,
+ * а supports() кастеров обязаны быть дизъюнктны — разделить их по типу свойства нельзя.
+ *
+ * '!Y-m-d' — «!» обнуляет время; без него подставится текущее, и fromDate
+ * станет зависеть от момента запроса.
+ */
+final class DateCaster implements ValueCaster
+{
+    private const string DATE_FORMAT = '!Y-m-d';
+
+    private const array DATE_TIME_FORMATS = [
+        'Y-m-d H:i:s',
+        \DateTimeInterface::ATOM,
+        'Y-m-d\TH:i:s',
+    ];
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->type === \DateTimeImmutable::class;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_string($value) === false || $value === '') {
+            return Result::fail(new Reason('type.date', 'Expected a date string.'));
+        }
+
+        $formats = preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1
+            ? [self::DATE_FORMAT]
+            : self::DATE_TIME_FORMATS;
+
+        foreach ($formats as $format) {
+            $date = \DateTimeImmutable::createFromFormat($format, $value);
+            $errors = \DateTimeImmutable::getLastErrors();
+
+            // На '2026-02-31' createFromFormat не падает, а молча переносит на 3 марта —
+            // это warning, и его обязательно проверять. getLastErrors(): array|false.
+            if ($date !== false && (\is_array($errors) === false || $errors['warning_count'] === 0)) {
+                return Result::ok($date);
+            }
+        }
+
+        return Result::fail(
+            new Reason('type.date', 'Expected a date in YYYY-MM-DD format or a datetime in ISO 8601 format.'),
+        );
+    }
+}

--- a/src/Payload/Cast/Decorator/ClampCaster.php
+++ b/src/Payload/Cast/Decorator/ClampCaster.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final readonly class ClampCaster implements ValueCaster
+{
+    public function __construct(
+        private ValueCaster $inner,
+        private int $min,
+        private int $max,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $this->inner->supports($plan);
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $result = $this->inner->cast($raw, $plan);
+
+        if ($result->isOk() === false) {
+            return $result;
+        }
+
+        $value = $result->value();
+
+        if (\is_int($value) === false) {
+            return $result;
+        }
+
+        return Result::ok(min(max($value, $this->min), $this->max));
+    }
+}

--- a/src/Payload/Cast/Decorator/FallbackCaster.php
+++ b/src/Payload/Cast/Decorator/FallbackCaster.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Восстанавливает только НЕ-типовые ошибки: '?sortBy=password' — неаккуратный клиент,
+ * молча даём дефолт; '?sortBy[]=a' (массив вместо строки) — сломанный клиент, отдаём 400.
+ */
+final readonly class FallbackCaster implements ValueCaster
+{
+    public function __construct(
+        private ValueCaster $inner,
+        private mixed $fallback,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $this->inner->supports($plan);
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $result = $this->inner->cast($raw, $plan);
+
+        if ($result->isOk()) {
+            return $result;
+        }
+
+        if (array_any($result->reasons(), static fn (Reason $r): bool => str_starts_with($r->code, 'type.'))) {
+            return $result;
+        }
+
+        return Result::ok($this->fallback);
+    }
+}

--- a/src/Payload/Cast/Decorator/NullableCaster.php
+++ b/src/Payload/Cast/Decorator/NullableCaster.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * null — это null. Пустая строка для ?string — тоже null: '?email=' значит «фильтр не задан»,
+ * а не «email равен пустой строке». Правило живёт здесь, отдельного атрибута под это нет.
+ */
+final readonly class NullableCaster implements ValueCaster
+{
+    public function __construct(
+        private ValueCaster $inner,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $this->inner->supports($plan);
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if ($value === null || ($plan->type === 'string' && \is_string($value) && trim($value) === '')) {
+            return Result::ok(null);
+        }
+
+        return $this->inner->cast($raw, $plan);
+    }
+}

--- a/src/Payload/Cast/Decorator/SplitCaster.php
+++ b/src/Payload/Cast/Decorator/SplitCaster.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Строка с разделителем → список до коллекционного кастера ('?ids=a,b,c').
+ *
+ * Уже-список проходит без изменений — синтаксис '?ids[]=a&ids[]=b' продолжает работать.
+ * Поэлементная обрезка не здесь: TrimCaster цепочки элемента режет 'a, b , c' сам.
+ * Лимит maxItems после разбиения проверяет базовый кастер.
+ */
+final readonly class SplitCaster implements ValueCaster
+{
+    /**
+     * @param non-empty-string $separator
+     */
+    public function __construct(
+        private ValueCaster $inner,
+        private string $separator,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $this->inner->supports($plan);
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_string($value) === false) {
+            return $this->inner->cast($raw, $plan);
+        }
+
+        // '?ids=' — это «прислали пустой список», а не список из одной пустой строки.
+        $items = $value === '' ? [] : explode($this->separator, $value);
+
+        return $this->inner->cast(RawValue::of($items, $raw->depth), $plan);
+    }
+}

--- a/src/Payload/Cast/Decorator/TrimCaster.php
+++ b/src/Payload/Cast/Decorator/TrimCaster.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Безусловная обрезка строковых свойств — триггер это объявленный тип string, атрибута нет.
+ * VO-свойства сюда не попадают: у них свой кастер, и обрезка там была бы ошибкой.
+ *
+ * Стандартного trim() недостаточно: его charlist не включает неразрывный пробел U+00A0
+ * и BOM U+FEFF — именно они приезжают при копировании из Word/Excel/веб-страницы.
+ * mb_trim() (PHP 8.4) режет unicode-пробелы включая U+00A0; BOM формально не пробел
+ * (категория Cf), поэтому дописан в charlist явно.
+ */
+final readonly class TrimCaster implements ValueCaster
+{
+    private const string CHARACTERS = " \t\n\r\0\x0B\u{00A0}\u{FEFF}";
+
+    public function __construct(
+        private ValueCaster $inner,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $this->inner->supports($plan);
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_string($value) === false) {
+            return $this->inner->cast($raw, $plan);
+        }
+
+        // Битый UTF-8 не должен доехать до БД; mb_trim() невалидную кодировку не отлавливает.
+        if (mb_check_encoding($value, 'UTF-8') === false) {
+            return Result::fail(new Reason('type.encoding', 'Expected valid UTF-8.'));
+        }
+
+        return $this->inner->cast(RawValue::of(mb_trim($value, self::CHARACTERS), $raw->depth), $plan);
+    }
+}

--- a/src/Payload/Cast/EnumCaster.php
+++ b/src/Payload/Cast/EnumCaster.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final class EnumCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->enumClass !== null;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $enumClass = $plan->enumClass;
+
+        if ($enumClass === null || is_subclass_of($enumClass, \BackedEnum::class) === false) {
+            return Result::fail(new Reason('type.enum', 'Expected an enum value.'));
+        }
+
+        $value = $raw->value;
+
+        // Массив/объект вместо скаляра — сломанный клиент: type.*, fallback такое не глотает.
+        if (\is_string($value) === false && \is_int($value) === false) {
+            return Result::fail(new Reason('type.enum', 'Expected a scalar enum value.'));
+        }
+
+        // Normalized — флаг здесь, а не декоратор: сопоставление требует $enum::cases(),
+        // которых декоратор не видит. Осознанная асимметрия со схемой декораторов.
+        if ($plan->normalized && \is_string($value)) {
+            $needle = mb_strtolower(trim($value));
+            foreach ($enumClass::cases() as $backedEnum) {
+                if (mb_strtolower((string)$backedEnum->value) === $needle) {
+                    return Result::ok($backedEnum);
+                }
+            }
+
+            return Result::fail(new Reason('enum.unknown', 'Unknown value.'));
+        }
+
+        $backedEnum = \is_int($value)
+            ? $enumClass::tryFrom($value)
+            : $this->tryFromString($enumClass, $value);
+
+        if ($backedEnum === null) {
+            return Result::fail(new Reason('enum.unknown', 'Unknown value.'));
+        }
+
+        return Result::ok($backedEnum);
+    }
+
+    /**
+     * @param class-string<\BackedEnum> $enumClass
+     */
+    private function tryFromString(string $enumClass, string $value): ?\BackedEnum
+    {
+        $backingType = (string)new \ReflectionEnum($enumClass)->getBackingType();
+
+        if ($backingType === 'int') {
+            $filtered = filter_var($value, \FILTER_VALIDATE_INT);
+
+            return $filtered === false ? null : $enumClass::tryFrom($filtered);
+        }
+
+        return $enumClass::tryFrom($value);
+    }
+}

--- a/src/Payload/Cast/FreeFormCaster.php
+++ b/src/Payload/Cast/FreeFormCaster.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Произвольная JSON-структура как есть (#[FreeForm]). Проверок формы и maxItems
+ * сознательно нет: от DoS защищают байтовый и глубинный лимиты RequestContext,
+ * а констрейнты валидатора на свойстве работают после сборки как обычно.
+ * Дизъюнктность с коллекционными кастерами гарантирует фабрика:
+ * freeForm ⇒ itemPlan и itemClass null.
+ */
+final class FreeFormCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->freeForm;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_array($value) === false) {
+            return Result::fail(new Reason('type.array', 'Expected an array.'));
+        }
+
+        return Result::ok($value);
+    }
+}

--- a/src/Payload/Cast/IntCaster.php
+++ b/src/Payload/Cast/IntCaster.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final class IntCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->type === 'int';
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        // '?limit=' даёт пустую строку: без явной ветки filter_var вернёт невнятную ошибку.
+        if ($value === '' || $value === null) {
+            return Result::fail(new Reason('type.int', 'Expected an integer.'));
+        }
+
+        if (\is_int($value)) {
+            return Result::ok($value);
+        }
+
+        if (\is_string($value)) {
+            $filtered = filter_var($value, \FILTER_VALIDATE_INT);
+            if ($filtered !== false) {
+                return Result::ok($filtered);
+            }
+        }
+
+        return Result::fail(new Reason('type.int', 'Expected an integer.'));
+    }
+}

--- a/src/Payload/Cast/NestedObjectCaster.php
+++ b/src/Payload/Cast/NestedObjectCaster.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+final readonly class NestedObjectCaster implements ValueCaster
+{
+    public function __construct(
+        private PlanFactory $plans,
+        private ObjectAssembler $assembler,
+    ) {
+    }
+
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->nestedClass !== null;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_array($value) === false) {
+            return Result::fail(new Reason('type.object', 'Expected an object.'));
+        }
+
+        // {} и [] неразличимы после json_decode — оба дают пустой массив. Отклонять
+        // через array_is_list() нельзя: {"address": {}} должен дойти до сборки
+        // и дать нормальные required-ошибки по полям, а не type.object.
+        $nestedClass = $plan->nestedClass
+            ?? throw new \LogicException(sprintf('Plan for property %s has no nested class.', $plan->name));
+
+        return $this->assembler->assemble($this->plans->build($nestedClass, nested: true), $value, $raw->depth + 1);
+    }
+}

--- a/src/Payload/Cast/ScalarCaster.php
+++ b/src/Payload/Cast/ScalarCaster.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Строки и float. Целые и bool — отдельные кастеры со своими правилами.
+ */
+final class ScalarCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->type === 'string' || $plan->type === 'float';
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        if ($plan->type === 'float') {
+            return $this->castFloat($raw->value);
+        }
+
+        return $this->castString($raw->value);
+    }
+
+    /**
+     * @return Result<string>
+     */
+    private function castString(mixed $value): Result
+    {
+        if (\is_string($value)) {
+            return Result::ok($value);
+        }
+
+        if (\is_int($value) || \is_float($value)) {
+            return Result::ok((string)$value);
+        }
+
+        return Result::fail(new Reason('type.string', 'Expected a string.'));
+    }
+
+    /**
+     * @return Result<float>
+     */
+    private function castFloat(mixed $value): Result
+    {
+        if (\is_float($value) || \is_int($value)) {
+            return Result::ok((float)$value);
+        }
+
+        if (\is_string($value) && $value !== '') {
+            $filtered = filter_var($value, \FILTER_VALIDATE_FLOAT);
+            if ($filtered !== false) {
+                return Result::ok($filtered);
+            }
+        }
+
+        return Result::fail(new Reason('type.float', 'Expected a number.'));
+    }
+}

--- a/src/Payload/Cast/ScalarCollectionCaster.php
+++ b/src/Payload/Cast/ScalarCollectionCaster.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Коллекции скалярных элементов (list<string> и т.п.). Дизъюнктность с CollectionCaster
+ * гарантирована взаимоисключением itemClass/itemPlan в плане.
+ */
+final class ScalarCollectionCaster implements ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool
+    {
+        return $plan->itemPlan !== null;
+    }
+
+    public function cast(RawValue $raw, PropertyPlan $plan): Result
+    {
+        $value = $raw->value;
+
+        if (\is_array($value) === false || array_is_list($value) === false) {
+            return Result::fail(new Reason('type.collection', 'Expected a list.'));
+        }
+
+        // Жёсткий предел здесь, а не Assert\Count: Count сработал бы после каста всех элементов.
+        if (\count($value) > $plan->maxItems) {
+            return Result::fail(new Reason(
+                'collection.too_many',
+                sprintf('Too many items; at most %d allowed.', $plan->maxItems),
+                ['max' => $plan->maxItems],
+            ));
+        }
+
+        $itemPlan = $plan->itemPlan
+            ?? throw new \LogicException(sprintf('Plan for property %s has no item plan.', $plan->name));
+        $chain = $itemPlan->casterChain
+            ?? throw new \LogicException(sprintf('Item plan for property %s has no caster chain.', $plan->name));
+
+        $items = [];
+        $reasons = [];
+
+        foreach ($value as $index => $item) {
+            $result = $chain->cast(RawValue::of($item, $raw->depth + 1), $itemPlan);
+
+            if ($result->isOk()) {
+                $items[] = $result->value();
+
+                continue;
+            }
+
+            foreach ($result->reasons() as $reason) {
+                $reasons[] = $reason->nest($index);
+            }
+
+            break;   // fail-fast, как и в ассемблере
+        }
+
+        if ($reasons !== []) {
+            return Result::fail(...$reasons);
+        }
+
+        return Result::ok($items);
+    }
+}

--- a/src/Payload/Cast/ValueCaster.php
+++ b/src/Payload/Cast/ValueCaster.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Cast;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Payload\Result;
+
+/**
+ * Кастер значения. supports() вызывается только при построении плана;
+ * в рантайме работает готовая цепочка $plan->casterChain.
+ *
+ * Реализации в src автоматически получают DI-тег payload.caster (_instanceof в services.yaml);
+ * декораторы из Cast/Decorator исключены из контейнера и строятся только PlanFactory.
+ */
+interface ValueCaster
+{
+    public function supports(PropertyPlan $plan): bool;
+
+    /**
+     * @return Result<mixed>
+     */
+    public function cast(RawValue $raw, PropertyPlan $plan): Result;
+}

--- a/src/Payload/Error/HttpProblemException.php
+++ b/src/Payload/Error/HttpProblemException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+/**
+ * Контракт для PayloadExceptionListener: любое исключение с этим интерфейсом
+ * превращается в ответ application/problem+json (RFC 9457).
+ */
+interface HttpProblemException extends \Throwable
+{
+    public function getStatusCode(): int;
+
+    public function getProblemType(): string;
+
+    public function getTitle(): string;
+
+    public function getViolations(): ViolationList;
+}

--- a/src/Payload/Error/MalformedPayloadException.php
+++ b/src/Payload/Error/MalformedPayloadException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class MalformedPayloadException extends \RuntimeException implements HttpProblemException
+{
+    public function __construct(
+        private readonly string $detail = 'Request body is not valid JSON.',
+        private readonly string $errorCode = 'json.malformed',
+    ) {
+        parent::__construct($this->detail);
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_BAD_REQUEST;
+    }
+
+    public function getProblemType(): string
+    {
+        return '/errors/malformed-payload';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Request payload is malformed';
+    }
+
+    public function getViolations(): ViolationList
+    {
+        return new ViolationList([new Violation('body', $this->detail, $this->errorCode)]);
+    }
+}

--- a/src/Payload/Error/PayloadExceptionListener.php
+++ b/src/Payload/Error/PayloadExceptionListener.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * RFC 9457 (application/problem+json) для исключений нового маппера.
+ * Легаси-подписчики и их форматы не затрагиваются: guard по своему интерфейсу.
+ *
+ * errors — массив даже в режиме fail-fast (всегда один элемент): клиенты сразу
+ * пишут итерацию, и включение накопления позже не сломает контракт.
+ */
+final class PayloadExceptionListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException',
+        ];
+    }
+
+    public function onKernelException(ExceptionEvent $event): void
+    {
+        $exception = $event->getThrowable();
+
+        if (($exception instanceof HttpProblemException) === false) {
+            return;
+        }
+
+        $response = new JsonResponse(
+            data: [
+                'type' => $exception->getProblemType(),
+                'title' => $exception->getTitle(),
+                'status' => $exception->getStatusCode(),
+                'errors' => $exception->getViolations(),
+            ],
+            status: $exception->getStatusCode(),
+            headers: ['Content-Type' => 'application/problem+json'],
+        );
+
+        $event->setResponse($response);
+    }
+}

--- a/src/Payload/Error/PayloadTooLargeException.php
+++ b/src/Payload/Error/PayloadTooLargeException.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+use Symfony\Component\HttpFoundation\Response;
+
+final class PayloadTooLargeException extends \RuntimeException implements HttpProblemException
+{
+    public function __construct(
+        private readonly int $maxBodyBytes,
+    ) {
+        parent::__construct(sprintf('Request body exceeds the limit of %d bytes.', $this->maxBodyBytes));
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_REQUEST_ENTITY_TOO_LARGE;
+    }
+
+    public function getProblemType(): string
+    {
+        return '/errors/payload-too-large';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Request payload is too large';
+    }
+
+    public function getViolations(): ViolationList
+    {
+        return new ViolationList([
+            new Violation(
+                'body',
+                sprintf('Request body exceeds the limit of %d bytes.', $this->maxBodyBytes),
+                'payload.too_large',
+            ),
+        ]);
+    }
+}

--- a/src/Payload/Error/PayloadViolationException.php
+++ b/src/Payload/Error/PayloadViolationException.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Граница 400/422 зафиксирована в ADR: 400 — не разобрали (кастеры),
+ * 422 — разобрали, но правило не выполнено (валидатор).
+ * Временно отключено: валидатор тоже отдаёт 400 (совместимость с потребителями).
+ */
+final class PayloadViolationException extends \RuntimeException implements HttpProblemException
+{
+    private function __construct(
+        private readonly ViolationList $violations,
+        private readonly int $statusCode,
+    ) {
+        parent::__construct('Request payload is invalid.');
+    }
+
+    public static function fromCast(ViolationList $violations): self
+    {
+        return new self($violations, Response::HTTP_BAD_REQUEST);
+    }
+
+    public static function fromValidator(ViolationList $violations): self
+    {
+        return new self($violations, Response::HTTP_BAD_REQUEST);
+    }
+
+    public function getStatusCode(): int
+    {
+        return $this->statusCode;
+    }
+
+    public function getProblemType(): string
+    {
+        return '/errors/validation';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Request payload is invalid';
+    }
+
+    public function getViolations(): ViolationList
+    {
+        return $this->violations;
+    }
+}

--- a/src/Payload/Error/PropertyPathConverter.php
+++ b/src/Payload/Error/PropertyPathConverter.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+/**
+ * Конвертация нотации симфонийского валидатора в указатели маппера:
+ * 'items[0].quantity' → 'items/0/quantity'. Без неё указатели от кастеров
+ * и от валидатора окажутся в разных нотациях и фронт не сможет их обрабатывать единообразно.
+ */
+final readonly class PropertyPathConverter
+{
+    public static function toPointer(string $propertyPath): string
+    {
+        return str_replace(['[', ']', '.'], ['/', '', '/'], $propertyPath);
+    }
+}

--- a/src/Payload/Error/Reason.php
+++ b/src/Payload/Error/Reason.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+/**
+ * Причина провала каста с ОТНОСИТЕЛЬНЫМ путём ('items/0/quantity').
+ *
+ * Кастер не знает своего абсолютного указателя; префикс источника ('body/', 'query/')
+ * приклеивается выше — при конвертации в Violation.
+ */
+final readonly class Reason
+{
+    /**
+     * @param array<string, scalar> $params только примитивы из публичного контракта — никаких сырых значений VO
+     */
+    public function __construct(
+        public string $code,
+        public string $detail,
+        public array $params = [],
+        public string $path = '',
+    ) {
+    }
+
+    public function nest(string|int $segment): self
+    {
+        $path = $this->path === '' ? (string)$segment : $segment . '/' . $this->path;
+
+        return new self($this->code, $this->detail, $this->params, $path);
+    }
+}

--- a/src/Payload/Error/StateConflictException.php
+++ b/src/Payload/Error/StateConflictException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * 409: конфликт состояния (email занят и т.п.). Указатель тот же, что у ошибок
+ * валидации ('body/email') — фронт кладёт сообщение под то же поле формы.
+ * Бросается доменными адаптерами при переводе роутов; листенер умеет с первого дня.
+ */
+final class StateConflictException extends \RuntimeException implements HttpProblemException
+{
+    public function __construct(
+        private readonly string $pointer,
+        private readonly string $detail,
+        private readonly string $errorCode = 'state.conflict',
+    ) {
+        parent::__construct($this->detail);
+    }
+
+    public function getStatusCode(): int
+    {
+        return Response::HTTP_CONFLICT;
+    }
+
+    public function getProblemType(): string
+    {
+        return '/errors/conflict';
+    }
+
+    public function getTitle(): string
+    {
+        return 'Request conflicts with the current state';
+    }
+
+    public function getViolations(): ViolationList
+    {
+        return new ViolationList([new Violation($this->pointer, $this->detail, $this->errorCode)]);
+    }
+}

--- a/src/Payload/Error/Violation.php
+++ b/src/Payload/Error/Violation.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+/**
+ * Ошибка с АБСОЛЮТНЫМ указателем ('body/items/0/quantity') — единица массива errors в ответе RFC 9457.
+ */
+final readonly class Violation implements \JsonSerializable
+{
+    public function __construct(
+        public string $pointer,
+        public string $detail,
+        public string $code,
+    ) {
+    }
+
+    /**
+     * К этому моменту путь Reason уже абсолютный: префикс источника — это pointer корневого
+     * свойства ('query/limit'), ассемблер докладывает его через nest(), спецкода не нужно.
+     */
+    public static function fromReason(Reason $reason): self
+    {
+        return new self($reason->path, $reason->detail, $reason->code);
+    }
+
+    /**
+     * @return array{pointer: string, detail: string, code: string}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pointer' => $this->pointer,
+            'detail' => $this->detail,
+            'code' => $this->code,
+        ];
+    }
+}

--- a/src/Payload/Error/ViolationList.php
+++ b/src/Payload/Error/ViolationList.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Error;
+
+/**
+ * @implements \IteratorAggregate<int, Violation>
+ */
+final readonly class ViolationList implements \Countable, \IteratorAggregate, \JsonSerializable
+{
+    /**
+     * @param list<Violation> $violations
+     */
+    public function __construct(
+        private array $violations,
+    ) {
+    }
+
+    public static function fromReasons(Reason ...$reasons): self
+    {
+        $violations = [];
+        foreach ($reasons as $reason) {
+            $violations[] = Violation::fromReason($reason);
+        }
+
+        return new self($violations);
+    }
+
+    /**
+     * @return list<Violation>
+     */
+    public function all(): array
+    {
+        return $this->violations;
+    }
+
+    public function count(): int
+    {
+        return \count($this->violations);
+    }
+
+    /**
+     * @return \ArrayIterator<int<0, max>, Violation>
+     */
+    public function getIterator(): \ArrayIterator
+    {
+        return new \ArrayIterator($this->violations);
+    }
+
+    /**
+     * @return list<array{pointer: string, detail: string, code: string}>
+     */
+    public function jsonSerialize(): array
+    {
+        $serialized = [];
+        foreach ($this->violations as $violation) {
+            $serialized[] = $violation->jsonSerialize();
+        }
+
+        return $serialized;
+    }
+}

--- a/src/Payload/ObjectAssembler.php
+++ b/src/Payload/ObjectAssembler.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Plan\PayloadPlan;
+
+/**
+ * Сборка объекта из массива — рекурсивно и без знания о HTTP: NestedObjectCaster
+ * вызывает того же ассемблера с планом дочернего класса. Разница между корнем и
+ * вложенностью ровно одна: у корня значения собраны из источников, у вложенного они уже в массиве.
+ *
+ * Единственный класс модуля, где допустимы @psalm-suppress: динамическая сборка
+ * из array<string, mixed> принципиально не типизируется. Гарантию даёт конструктор DTO —
+ * его параметры типизированы, и сюда доходят только значения, прошедшие кастеры.
+ */
+final class ObjectAssembler
+{
+    /**
+     * Вторая линия обороны от программной ошибки; защита от DoS — json_validate
+     * с лимитом глубины в RequestContext, до построения массива.
+     */
+    private const int MAX_DEPTH = 32;
+
+    /**
+     * @param array<array-key, mixed> $data
+     *
+     * @return Result<object>
+     */
+    public function assemble(PayloadPlan $plan, array $data, int $depth = 0): Result
+    {
+        if ($depth > self::MAX_DEPTH) {
+            return Result::fail(new Reason('depth.exceeded', 'Payload is nested too deeply.'));
+        }
+
+        $args = [];
+        $reasons = [];
+
+        foreach ($plan->properties as $property) {
+            if (\array_key_exists($property->key, $data) === false) {
+                // «Параметр не передан» и null — разные вещи: absent проверяется до кастера.
+                if ($property->hasDefault === false) {
+                    $reasons[] = new Reason('required', 'Required.', path: $property->pointer);
+                }
+
+                continue;
+            }
+
+            $chain = $property->casterChain ?? throw new \LogicException(
+                sprintf('Plan for %s::$%s has no caster chain.', $plan->class, $property->name),
+            );
+
+            $result = $chain->cast(RawValue::of($data[$property->key], $depth), $property);
+
+            if ($result->isOk()) {
+                $args[$property->name] = $result->value();
+
+                continue;
+            }
+
+            foreach ($result->reasons() as $reason) {
+                $reasons[] = $reason->nest($property->pointer);
+            }
+
+            break;   // fail-fast; убрать этот break = включить накопление ошибок
+        }
+
+        if ($reasons !== []) {
+            return Result::fail(...$reasons);
+        }
+
+        /** @psalm-suppress MixedMethodCall динамический new из плана — см. док-блок класса */
+        return Result::ok(new ($plan->class)(...$args));
+    }
+}

--- a/src/Payload/PayloadMapper.php
+++ b/src/Payload/PayloadMapper.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload;
+
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\Error\PropertyPathConverter;
+use Leads\Core\Payload\Error\Violation;
+use Leads\Core\Payload\Error\ViolationList;
+use Leads\Core\Payload\Plan\PayloadPlan;
+use Leads\Core\Payload\Source\ValueSource;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+/**
+ * Один маппер на весь проект. Здесь нет ни одного условия про HTTP-метод,
+ * режим чтения/записи или конкретный DTO: всё поведение выражено планом,
+ * скомпилированным из атрибутов DTO.
+ */
+final class PayloadMapper
+{
+    /** @var array<string, ValueSource>|null */
+    private ?array $sourceMap = null;
+
+    /**
+     * @param iterable<string, ValueSource> $sources tagged_iterator payload.source, индекс — ValueSource::key()
+     */
+    public function __construct(
+        private readonly Plan\PlanFactory $plans,
+        private readonly ObjectAssembler $assembler,
+        private readonly iterable $sources,
+        private readonly ValidatorInterface $validator,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @template T of object
+     *
+     * @param class-string<T> $class
+     * @param ?list<string> $groups
+     *
+     * @return T
+     */
+    public function map(string $class, Request $request, ?array $groups = null): object
+    {
+        $plan = $this->plans->build($class);
+        $context = RequestContext::fromRequest($request, $plan->maxBodyBytes);
+
+        // Учёт до извлечения: на этой стадии ещё видно исходное тело целиком.
+        $this->logUnknownBodyFields($plan, $context);
+
+        $data = [];
+        foreach ($plan->properties as $property) {
+            $source = $this->source($property->sourceKey);
+            if ($source->has($context, $property)) {
+                $data[$property->key] = $source->extract($context, $property);
+            }
+        }
+
+        $result = $this->assembler->assemble($plan, $data);
+
+        if ($result->isOk() === false) {
+            throw PayloadViolationException::fromCast(ViolationList::fromReasons(...$result->reasons()));
+        }
+
+        /** @var T $dto */
+        $dto = $result->value();
+
+        $this->validate($plan, $dto, $groups);
+
+        return $dto;
+    }
+
+    /**
+     * @param ?list<string> $groups
+     */
+    private function validate(PayloadPlan $plan, object $dto, ?array $groups): void
+    {
+        $violations = $this->validator->validate($dto, groups: $groups ?? $plan->groups);
+
+        // Fail-fast и на стадии валидатора: берётся первая ошибка, остальные отбрасываются.
+        foreach ($violations as $violation) {
+            throw PayloadViolationException::fromValidator(new ViolationList([
+                new Violation(
+                    $this->pointerFor($plan, $violation->getPropertyPath()),
+                    (string)$violation->getMessage(),
+                    'validation.failed',
+                ),
+            ]));
+        }
+    }
+
+    /**
+     * Валидатор отдаёт 'items[0].quantity' — приводим к 'body/items/0/quantity':
+     * первый сегмент маппится через pointerMap плана, остальное конвертируется по нотации.
+     */
+    private function pointerFor(PayloadPlan $plan, string $propertyPath): string
+    {
+        $pointer = PropertyPathConverter::toPointer($propertyPath);
+        $segments = explode('/', $pointer, 2);
+        $root = $plan->pointerMap[$segments[0]] ?? $segments[0];
+
+        return isset($segments[1]) ? $root . '/' . $segments[1] : $root;
+    }
+
+    private function logUnknownBodyFields(PayloadPlan $plan, RequestContext $context): void
+    {
+        $unknown = array_diff(array_map(strval(...), array_keys($context->body())), $plan->bodyKeys);
+
+        if ($unknown === []) {
+            return;
+        }
+
+        // Только имена, никогда значения: в неизвестном поле может оказаться пароль или токен.
+        // Query не логируем: utm_source и прочий шум внешнего мира забьёт выборку.
+        $this->logger->info('payload.unknown_fields', [
+            'dto' => $plan->class,
+            'route' => $context->routeName(),
+            'fields' => array_values($unknown),
+        ]);
+    }
+
+    private function source(string $key): ValueSource
+    {
+        if ($this->sourceMap === null) {
+            $this->sourceMap = [];
+            foreach ($this->sources as $sourceKey => $source) {
+                $this->sourceMap[$sourceKey] = $source;
+            }
+        }
+
+        return $this->sourceMap[$key]
+            ?? throw new \LogicException(sprintf('Unknown value source "%s".', $key));
+    }
+}

--- a/src/Payload/Plan/PayloadPlan.php
+++ b/src/Payload/Plan/PayloadPlan.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Plan;
+
+/**
+ * Скомпилированный план DTO целиком.
+ */
+final readonly class PayloadPlan
+{
+    /**
+     * @param class-string $class
+     * @param list<PropertyPlan> $properties
+     * @param list<string> $bodyKeys ключи тела, известные плану — для учёта неизвестных полей
+     * @param array<string, string> $pointerMap имя свойства → указатель ('toDate' → 'query/toDate')
+     * @param ?list<string> $groups
+     */
+    public function __construct(
+        public string $class,
+        public array $properties,
+        public array $bodyKeys,
+        public array $pointerMap,
+        public int $maxBodyBytes,
+        public ?array $groups,
+    ) {
+    }
+}

--- a/src/Payload/Plan/PlanFactory.php
+++ b/src/Payload/Plan/PlanFactory.php
@@ -1,0 +1,565 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Plan;
+
+use Leads\Core\Payload\Attribute\Clamp;
+use Leads\Core\Payload\Attribute\FallbackTo;
+use Leads\Core\Payload\Attribute\FreeForm;
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Payload\Attribute\FromHeader;
+use Leads\Core\Payload\Attribute\FromPath;
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\HttpPayload;
+use Leads\Core\Payload\Attribute\MaxItems;
+use Leads\Core\Payload\Attribute\Normalized;
+use Leads\Core\Payload\Attribute\Split;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\Decorator\ClampCaster;
+use Leads\Core\Payload\Cast\Decorator\FallbackCaster;
+use Leads\Core\Payload\Cast\Decorator\NullableCaster;
+use Leads\Core\Payload\Cast\Decorator\SplitCaster;
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\ValueCaster;
+use Symfony\Component\TypeInfo\Type;
+use Symfony\Component\TypeInfo\Type\BuiltinType;
+use Symfony\Component\TypeInfo\Type\CollectionType;
+use Symfony\Component\TypeInfo\Type\NullableType;
+use Symfony\Component\TypeInfo\Type\ObjectType;
+use Symfony\Component\TypeInfo\TypeContext\TypeContextFactory;
+use Symfony\Component\TypeInfo\TypeIdentifier;
+use Symfony\Component\TypeInfo\TypeResolver\PhpDocAwareReflectionTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\StringTypeResolver;
+use Symfony\Component\TypeInfo\TypeResolver\TypeResolver;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Constraints\Valid;
+
+/**
+ * Строит план DTO один раз: рефлексия и чтение атрибутов не должны выполняться на каждый запрос.
+ * Все ошибки конфигурации — \LogicException на построении, не в рантайме маппинга.
+ */
+final readonly class PlanFactory
+{
+    private PhpDocAwareReflectionTypeResolver $docBlockTypeResolver;
+
+    public function __construct(
+        private CasterRegistry $registry,
+    ) {
+        $stringTypeResolver = new StringTypeResolver();
+        $this->docBlockTypeResolver = new PhpDocAwareReflectionTypeResolver(
+            TypeResolver::create(),
+            $stringTypeResolver,
+            new TypeContextFactory($stringTypeResolver),
+        );
+    }
+
+    /**
+     * @param class-string $class
+     */
+    public function build(string $class, bool $nested = false): PayloadPlan
+    {
+        $reflection = new \ReflectionClass($class);
+        $constructor = $reflection->getConstructor()
+            ?? throw new \LogicException(sprintf('Request DTO %s must have a constructor.', $class));
+
+        $httpPayloadAttributes = $reflection->getAttributes(HttpPayload::class);
+        $httpPayload = $httpPayloadAttributes === []
+            ? new HttpPayload()
+            : $httpPayloadAttributes[0]->newInstance();
+
+        $properties = [];
+        $bodyKeys = [];
+        $pointerMap = [];
+
+        foreach ($constructor->getParameters() as $reflectionParameter) {
+            $property = $this->buildProperty($reflection, $reflectionParameter, $nested);
+            $properties[] = $property;
+            $pointerMap[$property->name] = $property->pointer;
+
+            if ($property->sourceKey === 'body') {
+                $bodyKeys[] = $property->key;
+            }
+        }
+
+        return new PayloadPlan(
+            class: $class,
+            properties: $properties,
+            bodyKeys: $bodyKeys,
+            pointerMap: $pointerMap,
+            maxBodyBytes: $httpPayload->maxBodyBytes,
+            groups: $httpPayload->groups,
+        );
+    }
+
+    /**
+     * @param \ReflectionClass<object> $reflection
+     */
+    private function buildProperty(
+        \ReflectionClass $reflection,
+        \ReflectionParameter $parameter,
+        bool $nested,
+    ): PropertyPlan {
+        $class = $reflection->getName();
+        $name = $parameter->getName();
+
+        [$sourceKey, $key] = $this->resolveSource($class, $parameter, $nested);
+
+        $type = $parameter->getType();
+        if (($type instanceof \ReflectionNamedType) === false) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s must have a single named type; union/intersection/missing types are not supported.',
+                $class,
+                $name,
+            ));
+        }
+
+        $typeName = $type->getName();
+        $enumClass = is_subclass_of($typeName, \BackedEnum::class) ? $typeName : null;
+        $nestedClass = $this->resolveNestedClass($typeName, $enumClass);
+        $normalized = $parameter->getAttributes(Normalized::class) !== [];
+        $freeForm = $parameter->getAttributes(FreeForm::class) !== [];
+        [$itemClass, $itemPlan] = $typeName === 'array'
+            ? $this->resolveCollectionItem($reflection, $name, $normalized)
+            : [null, null];
+
+        if ($freeForm && $typeName !== 'array') {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s: #[FreeForm] requires an array-typed property.',
+                $class,
+                $name,
+            ));
+        }
+
+        if ($freeForm && ($itemClass !== null || $itemPlan !== null)) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s combines #[FreeForm] with a declared item type; remove one of them.',
+                $class,
+                $name,
+            ));
+        }
+
+        if ($typeName === 'array' && $freeForm === false && $itemClass === null && $itemPlan === null) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s is a plain array; declare the item type'
+                . ' via "@param list<ItemClass>" or "@param list<string>" on the constructor docblock.',
+                $class,
+                $name,
+            ));
+        }
+
+        // Дочерние объекты конструируем сами — без Assert\Valid валидатор внутрь не зайдёт,
+        // и правила на вложенных полях молча не выполнятся. Каскад требуем только когда
+        // в графе дочернего класса правила есть: read-фильтрам без констрейнтов Valid не нужен.
+        $childClass = $nestedClass ?? $itemClass;
+
+        if (
+            $childClass !== null
+            && $this->hasValidConstraint($reflection, $name) === false
+            && $this->hasValidationRules($childClass)
+        ) {
+            throw new \LogicException(sprintf(
+                'Nested property %s::$%s requires #[Assert\Valid]:'
+                . ' %s declares validation constraints and they would be silently skipped.',
+                $class,
+                $name,
+                $childClass,
+            ));
+        }
+
+        $fallbackAttributes = $parameter->getAttributes(FallbackTo::class);
+        $clampAttributes = $parameter->getAttributes(Clamp::class);
+        $splitAttributes = $parameter->getAttributes(Split::class);
+
+        // Одно правило закрывает Split на скаляре, на объектной коллекции и на FreeForm.
+        if ($splitAttributes !== [] && $itemPlan === null) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s: #[Split] requires a scalar collection ("@param list<string>" docblock).',
+                $class,
+                $name,
+            ));
+        }
+
+        $maxItemsAttributes = $parameter->getAttributes(MaxItems::class);
+        $maxItems = $maxItemsAttributes === [] ? null : $maxItemsAttributes[0]->newInstance()->max;
+
+        // FreeForm попадает под это же правило: freeForm ⇒ itemClass и itemPlan null,
+        // а лимита элементов у произвольной структуры нет по дизайну.
+        if ($maxItems !== null && $itemClass === null && $itemPlan === null) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s: #[MaxItems] requires a collection property.',
+                $class,
+                $name,
+            ));
+        }
+
+        if ($maxItems !== null && $maxItems < 1) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s: #[MaxItems] must be a positive item limit, %d given.',
+                $class,
+                $name,
+                $maxItems,
+            ));
+        }
+
+        $plan = new PropertyPlan(
+            name: $name,
+            key: $key,
+            sourceKey: $sourceKey,
+            pointer: $nested ? $key : $sourceKey . '/' . $key,
+            type: $typeName,
+            nullable: $type->allowsNull(),
+            hasDefault: $parameter->isDefaultValueAvailable(),
+            isStringLike: $typeName === 'string',
+            enumClass: $enumClass,
+            nestedClass: $nestedClass,
+            itemClass: $itemClass,
+            itemPlan: $itemPlan,
+            maxItems: $maxItems ?? PropertyPlan::DEFAULT_MAX_ITEMS,
+            clamp: $clampAttributes === [] ? null : $clampAttributes[0]->newInstance(),
+            split: $splitAttributes === [] ? null : $splitAttributes[0]->newInstance(),
+            freeForm: $freeForm,
+            fallback: $fallbackAttributes === [] ? null : $fallbackAttributes[0]->newInstance()->value,
+            hasFallback: $fallbackAttributes !== [],
+            normalized: $normalized,
+        );
+
+        return $plan->withCasterChain($this->buildChain($class, $plan));
+    }
+
+    /**
+     * @return array{string, string} [sourceKey, key]
+     */
+    private function resolveSource(string $class, \ReflectionParameter $parameter, bool $nested): array
+    {
+        $name = $parameter->getName();
+        $sources = [];
+
+        foreach ($parameter->getAttributes(FromBody::class) as $attribute) {
+            $sources[] = ['body', $attribute->newInstance()->key ?? $name];
+        }
+        foreach ($parameter->getAttributes(FromQuery::class) as $attribute) {
+            $sources[] = ['query', $attribute->newInstance()->key ?? $name];
+        }
+        foreach ($parameter->getAttributes(FromPath::class) as $attribute) {
+            $sources[] = ['path', $attribute->newInstance()->key ?? $name];
+        }
+        foreach ($parameter->getAttributes(FromHeader::class) as $attribute) {
+            $sources[] = ['header', $attribute->newInstance()->name];
+        }
+
+        if ($nested) {
+            if ($sources !== []) {
+                // Значение вложенного свойства приходит из массива родителя; молча
+                // игнорировать атрибут нельзя — он выглядел бы работающим.
+                throw new \LogicException(sprintf(
+                    'Source attribute on nested property %s::$%s is meaningless;'
+                    . ' the value comes from the parent array.',
+                    $class,
+                    $name,
+                ));
+            }
+
+            return ['', $name];
+        }
+
+        if ($sources === []) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s has no source attribute;'
+                . ' declare #[FromBody], #[FromQuery], #[FromPath] or #[FromHeader].',
+                $class,
+                $name,
+            ));
+        }
+
+        if (\count($sources) > 1) {
+            throw new \LogicException(sprintf(
+                'Property %s::$%s declares more than one source attribute.',
+                $class,
+                $name,
+            ));
+        }
+
+        return $sources[0];
+    }
+
+    /**
+     * @return ?class-string
+     */
+    private function resolveNestedClass(string $typeName, ?string $enumClass): ?string
+    {
+        if ($enumClass !== null || class_exists($typeName) === false) {
+            return null;
+        }
+
+        // Дата — это скаляр публичного контракта со своим кастером, а не вложенная структура.
+        if (is_a($typeName, \DateTimeInterface::class, true)) {
+            return null;
+        }
+
+        return $typeName;
+    }
+
+    /**
+     * @param \ReflectionClass<object> $reflection
+     *
+     * @return array{?class-string, ?PropertyPlan} [itemClass, itemPlan] — ровно один не null,
+     *                                             либо оба null (тип элемента не объявлен)
+     */
+    private function resolveCollectionItem(
+        \ReflectionClass $reflection,
+        string $propertyName,
+        bool $normalized,
+    ): array {
+        $valueType = $this->resolveCollectionValueType($reflection, $propertyName);
+        $class = $reflection->getName();
+
+        // mixed приравнен к «тип не объявлен»: плоский array без докблока
+        // резолвится в array<array-key, mixed> — отличить его от list<mixed> нельзя.
+        $isMixed = $valueType instanceof BuiltinType && $valueType->getTypeIdentifier() === TypeIdentifier::MIXED;
+
+        if ($valueType === null || $isMixed) {
+            return [null, null];
+        }
+
+        if ($valueType instanceof NullableType) {
+            throw new \LogicException(sprintf(
+                'Nullable collection items on %s::$%s are not supported;'
+                . ' declare "@var list<string>", not "@var list<?string>".',
+                $class,
+                $propertyName,
+            ));
+        }
+
+        if ($valueType instanceof ObjectType) {
+            $itemClassName = $valueType->getClassName();
+
+            if (is_subclass_of($itemClassName, \BackedEnum::class)) {
+                return [
+                    null,
+                    $this->buildScalarItemPlan($class, $propertyName, $itemClassName, $itemClassName, $normalized),
+                ];
+            }
+
+            // Та же граница, что в resolveNestedClass: дата — скаляр публичного контракта.
+            if (is_a($itemClassName, \DateTimeInterface::class, true)) {
+                return [
+                    null,
+                    $this->buildScalarItemPlan($class, $propertyName, \DateTimeImmutable::class, null, $normalized),
+                ];
+            }
+
+            return [$itemClassName, null];
+        }
+
+        if ($valueType instanceof BuiltinType) {
+            $identifier = $valueType->getTypeIdentifier();
+            $scalars = [TypeIdentifier::STRING, TypeIdentifier::INT, TypeIdentifier::FLOAT, TypeIdentifier::BOOL];
+
+            if (\in_array($identifier, $scalars, true)) {
+                return [null, $this->buildScalarItemPlan($class, $propertyName, $identifier->value, null, $normalized)];
+            }
+        }
+
+        throw new \LogicException(sprintf(
+            'Unsupported collection item type "%s" for %s::$%s.',
+            (string)$valueType,
+            $class,
+            $propertyName,
+        ));
+    }
+
+    /**
+     * @param \ReflectionClass<object> $reflection
+     */
+    private function resolveCollectionValueType(\ReflectionClass $reflection, string $propertyName): ?Type
+    {
+        $type = $this->docBlockTypeResolver->resolve($reflection->getProperty($propertyName));
+
+        if ($type instanceof NullableType) {
+            $type = $type->getWrappedType();
+        }
+
+        if (($type instanceof CollectionType) === false) {
+            return null;
+        }
+
+        return $type->getCollectionValueType();
+    }
+
+    /**
+     * План скалярного элемента компилируется на build вместе с цепочкой —
+     * рантайм только гоняет её по элементам. Nullable/Clamp/Fallback на элементы
+     * сознательно не распространяются: это атрибуты уровня свойства.
+     *
+     * @param ?class-string<\BackedEnum> $enumClass
+     */
+    private function buildScalarItemPlan(
+        string $class,
+        string $propertyName,
+        string $itemType,
+        ?string $enumClass,
+        bool $normalized,
+    ): PropertyPlan {
+        $plan = new PropertyPlan(
+            name: $propertyName . '[]',
+            key: '',
+            sourceKey: '',
+            pointer: '',
+            type: $itemType,
+            nullable: false,
+            hasDefault: false,
+            isStringLike: $itemType === 'string',
+            enumClass: $enumClass,
+            normalized: $normalized,
+        );
+
+        return $plan->withCasterChain($this->buildChain($class, $plan));
+    }
+
+    /**
+     * @param \ReflectionClass<object> $reflection
+     */
+    private function hasValidConstraint(\ReflectionClass $reflection, string $propertyName): bool
+    {
+        return $reflection->getProperty($propertyName)->getAttributes(Valid::class) !== [];
+    }
+
+    /**
+     * Есть ли в графе классов хоть одно валидационное правило: атрибуты-констрейнты
+     * на классе, публичных методах (Assert\Callback) или параметрах конструктора,
+     * рекурсивно по вложенным объектам и коллекциям.
+     *
+     * @param class-string $class
+     * @param array<class-string, true> $visited
+     */
+    private function hasValidationRules(string $class, array &$visited = []): bool
+    {
+        if (isset($visited[$class])) {
+            return false;
+        }
+
+        $visited[$class] = true;
+        $reflection = new \ReflectionClass($class);
+
+        if ($reflection->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF) !== []) {
+            return true;
+        }
+
+        foreach ($reflection->getMethods(\ReflectionMethod::IS_PUBLIC) as $reflectionMethod) {
+            if ($reflectionMethod->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF) !== []) {
+                return true;
+            }
+        }
+
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null) {
+            return false;
+        }
+
+        foreach ($constructor->getParameters() as $reflectionParameter) {
+            $constraints = $reflectionParameter->getAttributes(Constraint::class, \ReflectionAttribute::IS_INSTANCEOF);
+
+            foreach ($constraints as $attribute) {
+                // Сам Valid правил не добавляет — правила ищет рекурсия ниже.
+                if (is_a($attribute->getName(), Valid::class, true) === false) {
+                    return true;
+                }
+            }
+
+            $childClass = $this->childClassOf($reflection, $reflectionParameter);
+
+            if ($childClass !== null && $this->hasValidationRules($childClass, $visited)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Класс дочернего объекта параметра: вложенный DTO либо item-класс коллекции.
+     * Скаляры контракта (enum, дата) — не дочерние структуры, как в resolveNestedClass.
+     *
+     * @param \ReflectionClass<object> $reflection
+     *
+     * @return ?class-string
+     */
+    private function childClassOf(\ReflectionClass $reflection, \ReflectionParameter $parameter): ?string
+    {
+        $type = $parameter->getType();
+
+        if (($type instanceof \ReflectionNamedType) === false) {
+            return null;
+        }
+
+        $typeName = $type->getName();
+
+        if ($typeName === 'array') {
+            $valueType = $this->resolveCollectionValueType($reflection, $parameter->getName());
+
+            if (($valueType instanceof ObjectType) === false) {
+                return null;
+            }
+
+            $typeName = $valueType->getClassName();
+        }
+
+        if (class_exists($typeName) === false || is_subclass_of($typeName, \BackedEnum::class)) {
+            return null;
+        }
+
+        if (is_a($typeName, \DateTimeInterface::class, true)) {
+            return null;
+        }
+
+        return $typeName;
+    }
+
+    private function buildChain(string $class, PropertyPlan $plan): ValueCaster
+    {
+        $caster = $this->registry->resolve($plan)
+            ?? throw new \LogicException(sprintf(
+                'No caster supports type "%s" (property %s::$%s).',
+                $plan->type,
+                $class,
+                $plan->name,
+            ));
+
+        // Порядок обёрток не произволен: Split самый внутренний (строка должна стать списком
+        // до всех проверок), Trim снаружи Nullable (иначе '?email=%20%20' не станет null),
+        // Fallback самый внешний — ловит провалы всей цепочки.
+        if ($plan->split !== null) {
+            $separator = $plan->split->separator;
+
+            if ($separator === '') {
+                throw new \LogicException(sprintf(
+                    'Property %s::$%s declares #[Split] with an empty separator.',
+                    $class,
+                    $plan->name,
+                ));
+            }
+
+            $caster = new SplitCaster($caster, $separator);
+        }
+
+        if ($plan->clamp !== null) {
+            $caster = new ClampCaster($caster, $plan->clamp->min, $plan->clamp->max);
+        }
+
+        if ($plan->nullable) {
+            $caster = new NullableCaster($caster);
+        }
+
+        if ($plan->isStringLike) {
+            $caster = new TrimCaster($caster);
+        }
+
+        if ($plan->hasFallback) {
+            $caster = new FallbackCaster($caster, $plan->fallback);
+        }
+
+        return $caster;
+    }
+}

--- a/src/Payload/Plan/PropertyPlan.php
+++ b/src/Payload/Plan/PropertyPlan.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Plan;
+
+use Leads\Core\Payload\Attribute\Clamp;
+use Leads\Core\Payload\Attribute\Split;
+use Leads\Core\Payload\Cast\ValueCaster;
+
+/**
+ * Скомпилированный план одного свойства DTO: всё, что нужно в рантайме,
+ * чтобы не читать атрибуты и рефлексию на каждый запрос.
+ */
+final readonly class PropertyPlan
+{
+    public const int DEFAULT_MAX_ITEMS = 1000;
+
+    /**
+     * @param string $name имя параметра конструктора
+     * @param string $key ключ в источнике (по умолчанию совпадает с name)
+     * @param string $sourceKey 'body'|'query'|'path'|'header'
+     * @param string $pointer абсолютный для корня ('query/limit'), относительный для вложенных ('quantity')
+     * @param string $type имя встроенного типа ('int', 'string', ...) либо class-string
+     * @param ?class-string<\BackedEnum> $enumClass
+     * @param ?class-string $nestedClass
+     * @param ?class-string $itemClass элементы-объекты; взаимоисключим с itemPlan —
+     *                                 это гарантирует дизъюнктность supports() коллекционных кастеров
+     * @param ?PropertyPlan $itemPlan скомпилированный план скалярного элемента коллекции
+     * @param mixed $fallback различаем «нет fallback» и FallbackTo(null) парой fallback + hasFallback
+     * @param bool $freeForm произвольная структура как есть; freeForm ⇒ itemPlan и itemClass null —
+     *                       дизъюнктность с коллекционными кастерами гарантирует фабрика на build
+     */
+    public function __construct(
+        public string $name,
+        public string $key,
+        public string $sourceKey,
+        public string $pointer,
+        public string $type,
+        public bool $nullable,
+        public bool $hasDefault,
+        public bool $isStringLike,
+        public ?string $enumClass = null,
+        public ?string $nestedClass = null,
+        public ?string $itemClass = null,
+        public ?self $itemPlan = null,
+        public int $maxItems = self::DEFAULT_MAX_ITEMS,
+        public ?Clamp $clamp = null,
+        public ?Split $split = null,
+        public bool $freeForm = false,
+        public mixed $fallback = null,
+        public bool $hasFallback = false,
+        public bool $normalized = false,
+        public ?ValueCaster $casterChain = null,
+    ) {
+    }
+
+    /**
+     * Цепочка навешивается после разрешения кастера по уже собранному плану —
+     * поэтому отдельный шаг, а не аргумент конструктора.
+     */
+    public function withCasterChain(ValueCaster $chain): self
+    {
+        return new self(
+            name: $this->name,
+            key: $this->key,
+            sourceKey: $this->sourceKey,
+            pointer: $this->pointer,
+            type: $this->type,
+            nullable: $this->nullable,
+            hasDefault: $this->hasDefault,
+            isStringLike: $this->isStringLike,
+            enumClass: $this->enumClass,
+            nestedClass: $this->nestedClass,
+            itemClass: $this->itemClass,
+            itemPlan: $this->itemPlan,
+            maxItems: $this->maxItems,
+            clamp: $this->clamp,
+            split: $this->split,
+            freeForm: $this->freeForm,
+            fallback: $this->fallback,
+            hasFallback: $this->hasFallback,
+            normalized: $this->normalized,
+            casterChain: $chain,
+        );
+    }
+}

--- a/src/Payload/RawValue.php
+++ b/src/Payload/RawValue.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload;
+
+/**
+ * Сырое значение из источника + текущая глубина вложенности.
+ *
+ * Глубина — вторая линия обороны от программной ошибки; защита от DoS живёт
+ * в RequestContext (json_validate с лимитом глубины до построения массива).
+ */
+final readonly class RawValue
+{
+    private function __construct(
+        public mixed $value,
+        public int $depth,
+    ) {
+    }
+
+    public static function of(mixed $value, int $depth = 0): self
+    {
+        return new self($value, $depth);
+    }
+}

--- a/src/Payload/RequestContext.php
+++ b/src/Payload/RequestContext.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload;
+
+use Leads\Core\Payload\Error\MalformedPayloadException;
+use Leads\Core\Payload\Error\PayloadTooLargeException;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Доступ к запросу для источников значений. Тело декодируется лениво, стадии строго по порядку:
+ * лимит размера по фактически прочитанному (до json_decode) → json_validate (структура и глубина,
+ * без построения массива) → json_decode.
+ */
+final class RequestContext
+{
+    private const int MAX_JSON_DEPTH = 32;
+
+    /** @var array<array-key, mixed>|null */
+    private ?array $body = null;
+
+    private function __construct(
+        private readonly Request $request,
+        private readonly int $maxBodyBytes,
+    ) {
+    }
+
+    public static function fromRequest(Request $request, int $maxBodyBytes): self
+    {
+        return new self($request, $maxBodyBytes);
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    public function body(): array
+    {
+        if ($this->body !== null) {
+            return $this->body;
+        }
+
+        $content = $this->request->getContent();
+
+        if (\strlen($content) > $this->maxBodyBytes) {
+            throw new PayloadTooLargeException($this->maxBodyBytes);
+        }
+
+        if ($content === '') {
+            return $this->body = [];
+        }
+
+        if (json_validate($content, self::MAX_JSON_DEPTH) === false) {
+            throw new MalformedPayloadException();
+        }
+
+        $decoded = json_decode($content, true);
+
+        if (\is_array($decoded) === false) {
+            throw new MalformedPayloadException('Request body must be a JSON object.', 'json.not_object');
+        }
+
+        return $this->body = $decoded;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function query(): array
+    {
+        return $this->request->query->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function pathParams(): array
+    {
+        /** @var array<string, mixed> */
+        return (array)$this->request->attributes->get('_route_params', []);
+    }
+
+    public function header(string $name): ?string
+    {
+        return $this->request->headers->get($name);
+    }
+
+    public function routeName(): string
+    {
+        $route = $this->request->attributes->get('_route', '');
+
+        return \is_string($route) ? $route : '';
+    }
+}

--- a/src/Payload/Resolver/PayloadValueResolver.php
+++ b/src/Payload/Resolver/PayloadValueResolver.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Resolver;
+
+use Leads\Core\Payload\Attribute\Payload;
+use Leads\Core\Payload\PayloadMapper;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/**
+ * Находит #[Payload] на аргументе контроллера — больше ничего не делает.
+ * Регистрируется автоконфигурацией (controller.argument_value_resolver), YAML не нужен.
+ */
+final readonly class PayloadValueResolver implements ValueResolverInterface
+{
+    public function __construct(
+        private PayloadMapper $mapper,
+    ) {
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        $attributes = $argument->getAttributesOfType(Payload::class, ArgumentMetadata::IS_INSTANCEOF);
+
+        if ($attributes === []) {
+            return [];
+        }
+
+        $type = $argument->getType();
+
+        if ($type === null || class_exists($type) === false) {
+            throw new \LogicException(sprintf(
+                'Argument $%s with #[Payload] must be typed with a request DTO class.',
+                $argument->getName(),
+            ));
+        }
+
+        return [$this->mapper->map($type, $request, $attributes[0]->groups)];
+    }
+}

--- a/src/Payload/Result.php
+++ b/src/Payload/Result.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload;
+
+use Leads\Core\Payload\Error\Reason;
+
+/**
+ * Результат каста: либо значение, либо список причин провала.
+ *
+ * Намеренно не монада: никаких map/flatMap/andThen — явный `if ($result->isOk())` читается лучше.
+ *
+ * @template-covariant T
+ */
+final readonly class Result
+{
+    /**
+     * @param T|null $value
+     * @param list<Reason> $reasons
+     */
+    private function __construct(
+        private bool $ok,
+        private mixed $value,
+        private array $reasons,
+    ) {
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $value
+     *
+     * @return self<V>
+     */
+    public static function ok(mixed $value): self
+    {
+        return new self(true, $value, []);
+    }
+
+    /**
+     * @return self<never>
+     */
+    public static function fail(Reason ...$reasons): self
+    {
+        /** @var self<never> $failed */
+        $failed = new self(false, null, array_values($reasons));
+
+        return $failed;
+    }
+
+    public function isOk(): bool
+    {
+        return $this->ok;
+    }
+
+    /**
+     * @return T
+     */
+    public function value(): mixed
+    {
+        if ($this->ok === false) {
+            throw new \LogicException('Cannot read value of a failed Result.');
+        }
+
+        /** @var T */
+        return $this->value;
+    }
+
+    /**
+     * @return list<Reason>
+     */
+    public function reasons(): array
+    {
+        return $this->reasons;
+    }
+}

--- a/src/Payload/Source/BodySource.php
+++ b/src/Payload/Source/BodySource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Source;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RequestContext;
+
+final readonly class BodySource implements ValueSource
+{
+    public static function key(): string
+    {
+        return 'body';
+    }
+
+    public function has(RequestContext $context, PropertyPlan $plan): bool
+    {
+        return \array_key_exists($plan->key, $context->body());
+    }
+
+    public function extract(RequestContext $context, PropertyPlan $plan): mixed
+    {
+        return $context->body()[$plan->key] ?? null;
+    }
+}

--- a/src/Payload/Source/HeaderSource.php
+++ b/src/Payload/Source/HeaderSource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Source;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RequestContext;
+
+final readonly class HeaderSource implements ValueSource
+{
+    public static function key(): string
+    {
+        return 'header';
+    }
+
+    public function has(RequestContext $context, PropertyPlan $plan): bool
+    {
+        return $context->header($plan->key) !== null;
+    }
+
+    public function extract(RequestContext $context, PropertyPlan $plan): mixed
+    {
+        return $context->header($plan->key);
+    }
+}

--- a/src/Payload/Source/PathSource.php
+++ b/src/Payload/Source/PathSource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Source;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RequestContext;
+
+final readonly class PathSource implements ValueSource
+{
+    public static function key(): string
+    {
+        return 'path';
+    }
+
+    public function has(RequestContext $context, PropertyPlan $plan): bool
+    {
+        return \array_key_exists($plan->key, $context->pathParams());
+    }
+
+    public function extract(RequestContext $context, PropertyPlan $plan): mixed
+    {
+        return $context->pathParams()[$plan->key] ?? null;
+    }
+}

--- a/src/Payload/Source/QuerySource.php
+++ b/src/Payload/Source/QuerySource.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Source;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RequestContext;
+
+final readonly class QuerySource implements ValueSource
+{
+    public static function key(): string
+    {
+        return 'query';
+    }
+
+    public function has(RequestContext $context, PropertyPlan $plan): bool
+    {
+        return \array_key_exists($plan->key, $context->query());
+    }
+
+    public function extract(RequestContext $context, PropertyPlan $plan): mixed
+    {
+        return $context->query()[$plan->key] ?? null;
+    }
+}

--- a/src/Payload/Source/ValueSource.php
+++ b/src/Payload/Source/ValueSource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Payload\Source;
+
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RequestContext;
+
+/**
+ * Источник значений. Реализации в src автоматически получают DI-тег payload.source
+ * (_instanceof в services.yaml) и индексируются по key() в tagged_iterator.
+ *
+ * has() отделён от extract(): «параметр не передан» и null — разные вещи,
+ * иначе PATCH не реализуем («не менять» и «обнулить» неразличимы).
+ */
+interface ValueSource
+{
+    public static function key(): string;
+
+    public function has(RequestContext $context, PropertyPlan $plan): bool;
+
+    public function extract(RequestContext $context, PropertyPlan $plan): mixed;
+}

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -10,3 +10,17 @@ services:
             - '../../DependencyInjection/'
             - '../../Pagination/'
             - '../../Exception/'
+            - '../../Payload/Attribute/'
+            - '../../Payload/Cast/Decorator/'
+            - '../../Payload/Plan/{PayloadPlan.php,PropertyPlan.php}'
+            - '../../Payload/Error/{Reason.php,Violation.php,ViolationList.php,PropertyPathConverter.php}'
+            - '../../Payload/Error/*Exception.php'
+            - '../../Payload/{RawValue.php,Result.php,RequestContext.php}'
+
+    Leads\Core\Payload\Cast\CasterRegistry:
+        arguments:
+            $casters: !tagged_iterator leads_core.payload.caster
+
+    Leads\Core\Payload\PayloadMapper:
+        arguments:
+            $sources: !tagged_iterator { tag: 'leads_core.payload.source', default_index_method: 'key' }

--- a/tests/Builder/PropertyPlanBuilder.php
+++ b/tests/Builder/PropertyPlanBuilder.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Builder;
+
+use Leads\Core\Payload\Attribute\Clamp;
+use Leads\Core\Payload\Attribute\Split;
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+
+final class PropertyPlanBuilder
+{
+    public function __construct(
+        public string $name = 'value',
+        public string $key = 'value',
+        public string $sourceKey = 'query',
+        public string $pointer = 'query/value',
+        public string $type = 'string',
+        public bool $nullable = false,
+        public bool $hasDefault = false,
+        public bool $isStringLike = false,
+        public ?string $enumClass = null,
+        public ?string $nestedClass = null,
+        public ?string $itemClass = null,
+        public ?PropertyPlan $itemPlan = null,
+        public int $maxItems = 1000,
+        public ?Clamp $clamp = null,
+        public ?Split $split = null,
+        public bool $freeForm = false,
+        public mixed $fallback = null,
+        public bool $hasFallback = false,
+        public bool $normalized = false,
+        public ?ValueCaster $casterChain = null,
+    ) {
+    }
+
+    public function build(): PropertyPlan
+    {
+        return new PropertyPlan(
+            name: $this->name,
+            key: $this->key,
+            sourceKey: $this->sourceKey,
+            pointer: $this->pointer,
+            type: $this->type,
+            nullable: $this->nullable,
+            hasDefault: $this->hasDefault,
+            isStringLike: $this->isStringLike,
+            enumClass: $this->enumClass,
+            nestedClass: $this->nestedClass,
+            itemClass: $this->itemClass,
+            itemPlan: $this->itemPlan,
+            maxItems: $this->maxItems,
+            clamp: $this->clamp,
+            split: $this->split,
+            freeForm: $this->freeForm,
+            fallback: $this->fallback,
+            hasFallback: $this->hasFallback,
+            normalized: $this->normalized,
+            casterChain: $this->casterChain,
+        );
+    }
+}

--- a/tests/Fixture/Payload/Invalid/AddressWithSourceAttribute.php
+++ b/tests/Fixture/Payload/Invalid/AddressWithSourceAttribute.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+
+/**
+ * Используется в тестах как ВЛОЖЕННЫЙ DTO: атрибут источника внутри — ошибка построения плана.
+ */
+final readonly class AddressWithSourceAttribute
+{
+    public function __construct(
+        #[FromQuery]
+        public string $city,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/FreeFormOnNonArrayRequest.php
+++ b/tests/Fixture/Payload/Invalid/FreeFormOnNonArrayRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FreeForm;
+use Leads\Core\Payload\Attribute\FromBody;
+
+final readonly class FreeFormOnNonArrayRequest
+{
+    public function __construct(
+        #[FromBody]
+        #[FreeForm]
+        public string $options,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/FreeFormWithItemTypeRequest.php
+++ b/tests/Fixture/Payload/Invalid/FreeFormWithItemTypeRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FreeForm;
+use Leads\Core\Payload\Attribute\FromBody;
+
+final readonly class FreeFormWithItemTypeRequest
+{
+    /**
+     * @param list<string> $options
+     */
+    public function __construct(
+        #[FromBody]
+        #[FreeForm]
+        public array $options = [],
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/MaxItemsBelowOneRequest.php
+++ b/tests/Fixture/Payload/Invalid/MaxItemsBelowOneRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Payload\Attribute\MaxItems;
+
+final readonly class MaxItemsBelowOneRequest
+{
+    /**
+     * @param list<string> $ids
+     */
+    public function __construct(
+        #[FromBody]
+        #[MaxItems(0)]
+        public array $ids,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/MaxItemsOnNonCollectionRequest.php
+++ b/tests/Fixture/Payload/Invalid/MaxItemsOnNonCollectionRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\MaxItems;
+
+final readonly class MaxItemsOnNonCollectionRequest
+{
+    public function __construct(
+        #[FromQuery]
+        #[MaxItems(5)]
+        public int $limit,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/MissingSourceRequest.php
+++ b/tests/Fixture/Payload/Invalid/MissingSourceRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+final readonly class MissingSourceRequest
+{
+    public function __construct(
+        public int $limit,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/MultipleSourcesRequest.php
+++ b/tests/Fixture/Payload/Invalid/MultipleSourcesRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Payload\Attribute\FromQuery;
+
+final readonly class MultipleSourcesRequest
+{
+    public function __construct(
+        #[FromQuery]
+        #[FromBody]
+        public string $name,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/NestedWithoutValidRequest.php
+++ b/tests/Fixture/Payload/Invalid/NestedWithoutValidRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Tests\Fixture\Payload\SampleItem;
+
+/**
+ * У SampleItem есть констрейнт (Assert\Positive) — без Assert\Valid он молча
+ * не выполнялся бы, поэтому план обязан не собраться.
+ */
+final readonly class NestedWithoutValidRequest
+{
+    public function __construct(
+        #[FromBody]
+        public SampleItem $item,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/NullableItemCollectionRequest.php
+++ b/tests/Fixture/Payload/Invalid/NullableItemCollectionRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+
+final readonly class NullableItemCollectionRequest
+{
+    /**
+     * @param list<?string> $tags
+     */
+    public function __construct(
+        #[FromBody]
+        public array $tags,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/PlainArrayRequest.php
+++ b/tests/Fixture/Payload/Invalid/PlainArrayRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class PlainArrayRequest
+{
+    public function __construct(
+        #[FromBody]
+        #[Assert\Valid]
+        public array $items,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/SplitEmptySeparatorRequest.php
+++ b/tests/Fixture/Payload/Invalid/SplitEmptySeparatorRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\Split;
+
+final readonly class SplitEmptySeparatorRequest
+{
+    /**
+     * @param list<string> $ids
+     */
+    public function __construct(
+        #[FromQuery]
+        #[Split(separator: '')]
+        public array $ids = [],
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/SplitOnNonCollectionRequest.php
+++ b/tests/Fixture/Payload/Invalid/SplitOnNonCollectionRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\Split;
+
+final readonly class SplitOnNonCollectionRequest
+{
+    public function __construct(
+        #[FromQuery]
+        #[Split]
+        public string $ids,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/UnknownTypeRequest.php
+++ b/tests/Fixture/Payload/Invalid/UnknownTypeRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+
+final readonly class UnknownTypeRequest
+{
+    public function __construct(
+        #[FromQuery]
+        public iterable $items,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/Invalid/UnsupportedItemCollectionRequest.php
+++ b/tests/Fixture/Payload/Invalid/UnsupportedItemCollectionRequest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload\Invalid;
+
+use Leads\Core\Payload\Attribute\FromBody;
+
+final readonly class UnsupportedItemCollectionRequest
+{
+    /**
+     * @param list<list<string>> $matrix
+     */
+    public function __construct(
+        #[FromBody]
+        public array $matrix,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleAddress.php
+++ b/tests/Fixture/Payload/SampleAddress.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+/**
+ * Вложенный DTO: атрибутов источника нет намеренно — значения приходят из массива родителя.
+ */
+final readonly class SampleAddress
+{
+    public function __construct(
+        public string $city,
+        public string $zip,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleFreeFormRequest.php
+++ b/tests/Fixture/Payload/SampleFreeFormRequest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\FreeForm;
+use Leads\Core\Payload\Attribute\FromBody;
+use Symfony\Component\Validator\Constraints as Assert;
+
+/**
+ * Фикстура механизма: произвольный JSON как есть (#[FreeForm]).
+ * Count на options пиннит, что констрейнты валидатора работают после сборки.
+ */
+final readonly class SampleFreeFormRequest
+{
+    public function __construct(
+        #[FromBody]
+        #[FreeForm]
+        #[Assert\Count(max: 5)]
+        public array $options = [],
+        #[FromBody]
+        #[FreeForm]
+        public ?array $meta = null,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleItem.php
+++ b/tests/Fixture/Payload/SampleItem.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Symfony\Component\Validator\Constraints as Assert;
+
+final readonly class SampleItem
+{
+    public function __construct(
+        public string $sku,
+        #[Assert\Positive]
+        public int $quantity,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleMaxItemsRequest.php
+++ b/tests/Fixture/Payload/SampleMaxItemsRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Payload\Attribute\MaxItems;
+
+final readonly class SampleMaxItemsRequest
+{
+    /**
+     * @param list<string> $ids
+     * @param list<string> $tags
+     */
+    public function __construct(
+        #[FromBody]
+        #[MaxItems(5)]
+        public array $ids,
+        #[FromBody]
+        public array $tags = [],
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleNestedRequest.php
+++ b/tests/Fixture/Payload/SampleNestedRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Symfony\Component\Validator\Constraints\Valid;
+
+/**
+ * Фикстура механизма: вложенный объект + коллекция + datetime из тела.
+ */
+final readonly class SampleNestedRequest
+{
+    /**
+     * @param list<SampleItem> $items
+     */
+    public function __construct(
+        #[FromBody]
+        public string $title,
+        #[FromBody]
+        #[Valid]
+        public SampleAddress $address,
+        #[FromBody]
+        #[Valid]
+        public array $items = [],
+        #[FromBody]
+        public ?\DateTimeImmutable $scheduledAt = null,
+        #[FromBody]
+        public ?float $totalPrice = null,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleRequest.php
+++ b/tests/Fixture/Payload/SampleRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\Clamp;
+use Leads\Core\Payload\Attribute\FallbackTo;
+use Leads\Core\Payload\Attribute\FromHeader;
+use Leads\Core\Payload\Attribute\FromPath;
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\HttpPayload;
+use Leads\Core\Payload\Attribute\Normalized;
+use Symfony\Component\Validator\Constraints as Assert;
+use Symfony\Component\Validator\Context\ExecutionContextInterface;
+
+/**
+ * Плоская фикстура механизма: задействует каждый скалярный кастер, каждый декоратор
+ * и каждый источник. Остаётся в проекте навсегда как регрессионный набор.
+ */
+#[HttpPayload(maxBodyBytes: 2048)]
+final readonly class SampleRequest
+{
+    public function __construct(
+        #[FromQuery]
+        #[Normalized]
+        #[FallbackTo(SampleSortField::CreatedAt)]
+        public SampleSortField $sortBy = SampleSortField::CreatedAt,
+        #[FromQuery]
+        #[Clamp(1, 100)]
+        public int $limit = 20,
+        #[FromQuery]
+        public int $page = 1,
+        #[FromQuery]
+        public ?string $email = null,
+        #[FromQuery]
+        public ?bool $archived = null,
+        #[FromQuery]
+        public ?\DateTimeImmutable $fromDate = null,
+        #[FromQuery]
+        public ?\DateTimeImmutable $toDate = null,
+        #[FromPath]
+        public ?string $projectId = null,
+        #[FromHeader('X-Request-Source')]
+        public ?string $requestSource = null,
+    ) {
+    }
+
+    #[Assert\Callback]
+    public function validateDateRange(ExecutionContextInterface $context): void
+    {
+        if ($this->fromDate !== null && $this->toDate !== null && $this->fromDate > $this->toDate) {
+            $context->buildViolation('fromDate must be before or equal to toDate.')
+                ->atPath('toDate')
+                ->addViolation();
+        }
+    }
+}

--- a/tests/Fixture/Payload/SampleScalarCollectionRequest.php
+++ b/tests/Fixture/Payload/SampleScalarCollectionRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\FromBody;
+use Leads\Core\Payload\Attribute\Normalized;
+
+/**
+ * Фикстура механизма: коллекции скалярных элементов из тела.
+ * Сознательно без Assert\Valid — скалярным коллекциям каскад не нужен.
+ */
+final readonly class SampleScalarCollectionRequest
+{
+    /**
+     * @param list<string> $sourcesIds
+     * @param list<int> $counts
+     * @param list<SampleSortField> $sorts
+     * @param list<\DateTimeImmutable> $dates
+     * @param ?list<string> $tags
+     */
+    public function __construct(
+        #[FromBody]
+        public array $sourcesIds = [],
+        #[FromBody]
+        public array $counts = [],
+        #[FromBody]
+        #[Normalized]
+        public array $sorts = [],
+        #[FromBody]
+        public array $dates = [],
+        #[FromBody]
+        public ?array $tags = null,
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleSortField.php
+++ b/tests/Fixture/Payload/SampleSortField.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+/**
+ * camelCase-кейс обязателен: ловит реализацию Normalized через strtoupper
+ * ('LASTNAME' !== 'lastName' при сравнении с upper-кейсами).
+ */
+enum SampleSortField: string
+{
+    case CreatedAt = 'createdAt';
+    case LastName = 'lastName';
+    case Id = 'id';
+}

--- a/tests/Fixture/Payload/SampleSplitFilter.php
+++ b/tests/Fixture/Payload/SampleSplitFilter.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\Split;
+
+/**
+ * Вложенный фильтр с CSV-списком — воспроизводит легаси-форму '?filter[ids]=a,b,c'.
+ */
+final readonly class SampleSplitFilter
+{
+    /**
+     * @param list<string> $ids
+     */
+    public function __construct(
+        #[Split]
+        public array $ids = [],
+    ) {
+    }
+}

--- a/tests/Fixture/Payload/SampleSplitRequest.php
+++ b/tests/Fixture/Payload/SampleSplitRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Fixture\Payload;
+
+use Leads\Core\Payload\Attribute\FromQuery;
+use Leads\Core\Payload\Attribute\Split;
+
+/**
+ * Фикстура механизма: CSV-списки из query (#[Split]).
+ */
+final readonly class SampleSplitRequest
+{
+    /**
+     * @param list<string> $ids
+     * @param list<int> $counts
+     * @param ?list<string> $tags
+     */
+    public function __construct(
+        #[FromQuery]
+        #[Split]
+        public array $ids = [],
+        #[FromQuery]
+        #[Split(separator: '|')]
+        public array $counts = [],
+        #[FromQuery]
+        #[Split]
+        public ?array $tags = null,
+        #[FromQuery]
+        public ?SampleSplitFilter $filter = null,
+    ) {
+    }
+}

--- a/tests/Integration/Payload/PayloadWiringTest.php
+++ b/tests/Integration/Payload/PayloadWiringTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Integration\Payload;
+
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Tests\Fixture\Payload\SampleNestedRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use Leads\Core\Tests\Integration\TestKernel;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Сквозная проверка DI-wiring бандла: маппер из контейнера со всеми tagged-кастерами
+ * и источниками собирает фикстуры и отдаёт указатели в формате контракта.
+ */
+final class PayloadWiringTest extends KernelTestCase
+{
+    public function testFlatFixtureIsMappedThroughContainerWiredMapper(): void
+    {
+        $mapper = $this->mapper();
+
+        $request = Request::create('/sample?sortBy=LASTNAME&limit=500&email=%20%20');
+        $request->headers->set('X-Request-Source', 'mobile');
+        $request->attributes->set('_route_params', ['projectId' => 'uuid-42']);
+
+        $dto = $mapper->map(SampleRequest::class, $request);
+
+        $this->assertInstanceOf(SampleRequest::class, $dto);
+        $this->assertSame(SampleSortField::LastName, $dto->sortBy);
+        $this->assertSame(100, $dto->limit);
+        $this->assertNull($dto->email);
+        $this->assertSame('mobile', $dto->requestSource);
+        $this->assertSame('uuid-42', $dto->projectId);
+    }
+
+    public function testNestedFixtureIsMappedThroughContainerWiredMapper(): void
+    {
+        $mapper = $this->mapper();
+
+        $request = Request::create(
+            uri: '/orders',
+            method: Request::METHOD_POST,
+            content: (string)json_encode([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => [['sku' => 'a-1', 'quantity' => 2]],
+            ]),
+        );
+
+        $dto = $mapper->map(SampleNestedRequest::class, $request);
+
+        $this->assertInstanceOf(SampleNestedRequest::class, $dto);
+        $this->assertSame('Yerevan', $dto->address->city);
+        $this->assertCount(1, $dto->items);
+        $this->assertSame(2, $dto->items[0]->quantity);
+    }
+
+    public function testErrorPointerFormatSurvivesContainerWiring(): void
+    {
+        $mapper = $this->mapper();
+
+        $request = Request::create(
+            uri: '/orders',
+            method: Request::METHOD_POST,
+            content: (string)json_encode([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => [['sku' => 'a-1', 'quantity' => 'abc']],
+            ]),
+        );
+
+        try {
+            $mapper->map(SampleNestedRequest::class, $request);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $this->assertSame('body/items/0/quantity', $payloadViolationException->getViolations()->all()[0]->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // FrameworkBundle::boot() регистрирует exception handler и не снимает его —
+        // без restore PHPUnit помечает тест как risky.
+        restore_exception_handler();
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+
+    private function mapper(): PayloadMapper
+    {
+        self::bootKernel();
+
+        $mapper = self::getContainer()->get('leads_core.test.payload_mapper');
+        $this->assertInstanceOf(PayloadMapper::class, $mapper);
+
+        return $mapper;
+    }
+}

--- a/tests/Integration/TestKernel.php
+++ b/tests/Integration/TestKernel.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Integration;
+
+use Leads\Core\LeadsCoreBundle;
+use Leads\Core\Payload\PayloadMapper;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+/**
+ * Минимальное ядро для интеграционных тестов бандла: FrameworkBundle + LeadsCoreBundle,
+ * без роутов и собственной конфигурации — проверяется ровно та проводка,
+ * которую получит потребитель библиотеки.
+ */
+final class TestKernel extends Kernel
+{
+    use MicroKernelTrait;
+
+    public function registerBundles(): iterable
+    {
+        return [new FrameworkBundle(), new LeadsCoreBundle()];
+    }
+
+    public function getCacheDir(): string
+    {
+        return sys_get_temp_dir() . '/leads-core-test-kernel/cache/' . $this->environment;
+    }
+
+    public function getLogDir(): string
+    {
+        return sys_get_temp_dir() . '/leads-core-test-kernel/log';
+    }
+
+    protected function configureContainer(ContainerConfigurator $container): void
+    {
+        $container->extension('framework', [
+            'secret' => 'test',
+            'test' => true,
+            'http_method_override' => false,
+            'php_errors' => ['log' => true],
+            'validation' => ['email_validation_mode' => 'html5'],
+        ]);
+
+        // Сервисы бандла приватные — для теста проводки нужен публичный алиас.
+        $container->services()
+            ->alias('leads_core.test.payload_mapper', PayloadMapper::class)
+            ->public();
+    }
+
+    protected function configureRoutes(RoutingConfigurator $routes): void
+    {
+    }
+}

--- a/tests/Unit/Payload/Cast/BoolCasterTest.php
+++ b/tests/Unit/Payload/Cast/BoolCasterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class BoolCasterTest extends TestCase
+{
+    #[DataProvider('cases')]
+    public function testCast(mixed $input, bool $ok, mixed $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'bool')->build();
+
+        $result = new BoolCaster()->cast(RawValue::of($input), $plan);
+
+        $this->assertSame($ok, $result->isOk());
+        if ($ok) {
+            $this->assertSame($expected, $result->value());
+        } else {
+            $this->assertSame($expected, $result->reasons()[0]->code);
+        }
+    }
+
+    public static function cases(): iterable
+    {
+        yield 'true' => [true, true, true];
+        yield 'false' => [false, true, false];
+        yield 'string true' => ['true', true, true];
+        yield 'string false' => ['false', true, false];
+        yield 'string 1' => ['1', true, true];
+        yield 'string 0' => ['0', true, false];
+        yield 'string on' => ['on', true, true];
+        yield 'string off' => ['off', true, false];
+        yield 'int 1' => [1, true, true];
+        yield 'int 0' => [0, true, false];
+        yield 'letters rejected' => ['abc', false, 'type.bool'];
+        yield 'null rejected' => [null, false, 'type.bool'];
+        yield 'array rejected' => [[true], false, 'type.bool'];
+    }
+}

--- a/tests/Unit/Payload/Cast/CasterRegistryTest.php
+++ b/tests/Unit/Payload/Cast/CasterRegistryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CasterRegistryTest extends TestCase
+{
+    public function testResolvesFirstSupportingCaster(): void
+    {
+        $registry = new CasterRegistry([new ScalarCaster(), new IntCaster(), new BoolCaster()]);
+
+        $resolved = $registry->resolve(new PropertyPlanBuilder(type: 'int')->build());
+
+        $this->assertInstanceOf(IntCaster::class, $resolved);
+    }
+
+    public function testReturnsNullWhenNoCasterSupportsType(): void
+    {
+        $registry = new CasterRegistry([new ScalarCaster(), new IntCaster()]);
+
+        $resolved = $registry->resolve(new PropertyPlanBuilder(type: \SplStack::class)->build());
+
+        $this->assertNull($resolved);
+    }
+}

--- a/tests/Unit/Payload/Cast/DateCasterTest.php
+++ b/tests/Unit/Payload/Cast/DateCasterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class DateCasterTest extends TestCase
+{
+    public function testDateIsParsedWithZeroedTime(): void
+    {
+        $result = new DateCaster()->cast(RawValue::of('2026-08-07'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $value = $result->value();
+        $this->assertInstanceOf(\DateTimeImmutable::class, $value);
+        $this->assertSame('2026-08-07 00:00:00', $value->format('Y-m-d H:i:s'));
+    }
+
+    #[DataProvider('dateTimeCases')]
+    public function testDateTimeFormatsAreParsed(string $input, string $expected): void
+    {
+        $result = new DateCaster()->cast(RawValue::of($input), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $value = $result->value();
+        $this->assertInstanceOf(\DateTimeImmutable::class, $value);
+        $this->assertSame($expected, $value->format('Y-m-d H:i:s'));
+    }
+
+    public static function dateTimeCases(): iterable
+    {
+        yield 'sql datetime' => ['2026-08-07 10:30:00', '2026-08-07 10:30:00'];
+        yield 'iso 8601 with offset' => ['2026-08-07T10:30:00+00:00', '2026-08-07 10:30:00'];
+        yield 'iso 8601 without offset' => ['2026-08-07T10:30:00', '2026-08-07 10:30:00'];
+    }
+
+    #[DataProvider('invalidCases')]
+    public function testInvalidValuesAreRejected(mixed $input): void
+    {
+        $result = new DateCaster()->cast(RawValue::of($input), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.date', $result->reasons()[0]->code);
+    }
+
+    public static function invalidCases(): iterable
+    {
+        yield 'wrong format' => ['07.08.2026'];
+        yield 'impossible date silently rolled over by PHP' => ['2026-02-31'];
+        yield 'impossible datetime' => ['2026-02-31 10:00:00'];
+        yield 'empty string' => [''];
+        yield 'null' => [null];
+        yield 'array' => [['2026-08-07']];
+        yield 'garbage' => ['not-a-date'];
+    }
+
+    private function plan(): PropertyPlan
+    {
+        return new PropertyPlanBuilder(type: \DateTimeImmutable::class)->build();
+    }
+}

--- a/tests/Unit/Payload/Cast/Decorator/ClampCasterTest.php
+++ b/tests/Unit/Payload/Cast/Decorator/ClampCasterTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\Decorator\ClampCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ClampCasterTest extends TestCase
+{
+    #[DataProvider('cases')]
+    public function testClampsIntoRange(mixed $input, int $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'int')->build();
+
+        $result = new ClampCaster(new IntCaster(), 1, 100)->cast(RawValue::of($input), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($expected, $result->value());
+    }
+
+    public static function cases(): iterable
+    {
+        yield 'above max' => ['500', 100];
+        yield 'below min' => ['0', 1];
+        yield 'negative' => [-5, 1];
+        yield 'inside range' => [50, 50];
+        yield 'at min' => [1, 1];
+        yield 'at max' => [100, 100];
+    }
+
+    public function testInnerFailureIsPassedThrough(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'int')->build();
+
+        $result = new ClampCaster(new IntCaster(), 1, 100)->cast(RawValue::of('abc'), $plan);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.int', $result->reasons()[0]->code);
+    }
+}

--- a/tests/Unit/Payload/Cast/Decorator/FallbackCasterTest.php
+++ b/tests/Unit/Payload/Cast/Decorator/FallbackCasterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\Decorator\FallbackCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use PHPUnit\Framework\TestCase;
+
+final class FallbackCasterTest extends TestCase
+{
+    public function testSuccessfulCastIsPassedThrough(): void
+    {
+        $result = $this->caster()->cast(RawValue::of('lastName'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(SampleSortField::LastName, $result->value());
+    }
+
+    public function testRecoverableErrorIsReplacedWithFallback(): void
+    {
+        $result = $this->caster()->cast(RawValue::of('password'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(SampleSortField::CreatedAt, $result->value());
+    }
+
+    public function testTypeErrorIsNotSwallowed(): void
+    {
+        $result = $this->caster()->cast(RawValue::of(['a', 'b']), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.enum', $result->reasons()[0]->code);
+    }
+
+    private function caster(): FallbackCaster
+    {
+        return new FallbackCaster(new EnumCaster(), SampleSortField::CreatedAt);
+    }
+
+    private function plan(): PropertyPlan
+    {
+        return new PropertyPlanBuilder(
+            type: SampleSortField::class,
+            enumClass: SampleSortField::class,
+            fallback: SampleSortField::CreatedAt,
+            hasFallback: true,
+        )->build();
+    }
+}

--- a/tests/Unit/Payload/Cast/Decorator/NullableCasterTest.php
+++ b/tests/Unit/Payload/Cast/Decorator/NullableCasterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\Decorator\NullableCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class NullableCasterTest extends TestCase
+{
+    public function testNullBecomesNull(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new NullableCaster(new ScalarCaster())->cast(RawValue::of(null), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertNull($result->value());
+    }
+
+    public function testBlankStringForStringTypeBecomesNull(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new NullableCaster(new ScalarCaster())->cast(RawValue::of(''), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertNull($result->value());
+    }
+
+    public function testSpacesOnlyStringForStringTypeBecomesNull(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new NullableCaster(new ScalarCaster())->cast(RawValue::of('   '), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertNull($result->value());
+    }
+
+    public function testBlankStringForIntTypeIsNotSwallowed(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'int')->build();
+
+        $result = new NullableCaster(new IntCaster())->cast(RawValue::of(''), $plan);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.int', $result->reasons()[0]->code);
+    }
+
+    public function testNonBlankValueIsDelegated(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new NullableCaster(new ScalarCaster())->cast(RawValue::of('john'), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame('john', $result->value());
+    }
+}

--- a/tests/Unit/Payload/Cast/Decorator/SplitCasterTest.php
+++ b/tests/Unit/Payload/Cast/Decorator/SplitCasterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\Decorator\SplitCaster;
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class SplitCasterTest extends TestCase
+{
+    public function testStringIsSplitIntoList(): void
+    {
+        $result = $this->caster()->cast(RawValue::of('a,b,c'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['a', 'b', 'c'], $result->value());
+    }
+
+    public function testItemsAreTrimmedByItemChain(): void
+    {
+        $result = $this->caster()->cast(RawValue::of('a, b , c'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['a', 'b', 'c'], $result->value());
+    }
+
+    public function testEmptyStringIsEmptyList(): void
+    {
+        $result = $this->caster()->cast(RawValue::of(''), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame([], $result->value());
+    }
+
+    public function testRealListPassesThroughUnchanged(): void
+    {
+        $result = $this->caster()->cast(RawValue::of(['a', 'b']), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['a', 'b'], $result->value());
+    }
+
+    public function testNonStringNonArrayFailsInInnerCaster(): void
+    {
+        $result = $this->caster()->cast(RawValue::of(5), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.collection', $result->reasons()[0]->code);
+    }
+
+    public function testCustomSeparator(): void
+    {
+        $result = $this->caster(separator: '|')->cast(RawValue::of('a|b'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['a', 'b'], $result->value());
+    }
+
+    private function caster(string $separator = ','): SplitCaster
+    {
+        return new SplitCaster(new ScalarCollectionCaster(), $separator);
+    }
+
+    private function plan(): PropertyPlan
+    {
+        $itemPlan = new PropertyPlanBuilder(
+            name: 'ids[]',
+            key: '',
+            sourceKey: '',
+            pointer: '',
+            isStringLike: true,
+        )->build();
+
+        return new PropertyPlanBuilder(
+            name: 'ids',
+            key: 'ids',
+            sourceKey: 'query',
+            pointer: 'query/ids',
+            type: 'array',
+            itemPlan: $itemPlan->withCasterChain(new TrimCaster(new ScalarCaster())),
+        )->build();
+    }
+}

--- a/tests/Unit/Payload/Cast/Decorator/TrimCasterTest.php
+++ b/tests/Unit/Payload/Cast/Decorator/TrimCasterTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast\Decorator;
+
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class TrimCasterTest extends TestCase
+{
+    #[DataProvider('trimCases')]
+    public function testTrimsWhitespaceIncludingUnicode(string $input, string $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new TrimCaster(new ScalarCaster())->cast(RawValue::of($input), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($expected, $result->value());
+    }
+
+    public static function trimCases(): iterable
+    {
+        yield 'plain spaces' => ['  john  ', 'john'];
+        yield 'tabs and newlines' => ["\t john \n", 'john'];
+        yield 'non-breaking space U+00A0' => ["\u{00A0}john\u{00A0}", 'john'];
+        yield 'BOM U+FEFF' => ["\u{FEFF}john\u{FEFF}", 'john'];
+        yield 'mixed unicode padding' => ["\u{FEFF}\u{00A0} john \u{00A0}", 'john'];
+        yield 'inner spaces kept' => ['  john doe  ', 'john doe'];
+    }
+
+    public function testInvalidUtf8IsRejectedBeforeTrim(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new TrimCaster(new ScalarCaster())->cast(RawValue::of("\xC3\x28"), $plan);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.encoding', $result->reasons()[0]->code);
+    }
+
+    public function testNonStringValueIsDelegatedUntouched(): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new TrimCaster(new ScalarCaster())->cast(RawValue::of(5), $plan);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame('5', $result->value());
+    }
+}

--- a/tests/Unit/Payload/Cast/EnumCasterTest.php
+++ b/tests/Unit/Payload/Cast/EnumCasterTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class EnumCasterTest extends TestCase
+{
+    public function testExactValueMatches(): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of('lastName'), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(SampleSortField::LastName, $result->value());
+    }
+
+    public function testUnknownValueIsRecoverableError(): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of('password'), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('enum.unknown', $result->reasons()[0]->code);
+    }
+
+    #[DataProvider('normalizedCases')]
+    public function testNormalizedMatchesCaseInsensitively(string $input, SampleSortField $expected): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of($input), $this->plan(normalized: true));
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($expected, $result->value());
+    }
+
+    public static function normalizedCases(): iterable
+    {
+        yield 'upper camelCase value' => ['LASTNAME', SampleSortField::LastName];
+        yield 'lower camelCase value' => ['lastname', SampleSortField::LastName];
+        yield 'exact value' => ['createdAt', SampleSortField::CreatedAt];
+        yield 'padded value' => [' id ', SampleSortField::Id];
+    }
+
+    public function testNormalizedUnknownValueIsRecoverableError(): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of('phone'), $this->plan(normalized: true));
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('enum.unknown', $result->reasons()[0]->code);
+    }
+
+    public function testArrayIsTypeError(): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of(['a', 'b']), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.enum', $result->reasons()[0]->code);
+    }
+
+    public function testNormalizedArrayIsStillTypeError(): void
+    {
+        $result = new EnumCaster()->cast(RawValue::of(['a', 'b']), $this->plan(normalized: true));
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.enum', $result->reasons()[0]->code);
+    }
+
+    private function plan(bool $normalized = false): \Leads\Core\Payload\Plan\PropertyPlan
+    {
+        return new PropertyPlanBuilder(
+            type: SampleSortField::class,
+            enumClass: SampleSortField::class,
+            normalized: $normalized,
+        )->build();
+    }
+}

--- a/tests/Unit/Payload/Cast/FreeFormCasterTest.php
+++ b/tests/Unit/Payload/Cast/FreeFormCasterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\FreeFormCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class FreeFormCasterTest extends TestCase
+{
+    public function testSupportsOnlyFreeFormPlans(): void
+    {
+        $caster = new FreeFormCaster();
+
+        $this->assertTrue($caster->supports(new PropertyPlanBuilder(type: 'array', freeForm: true)->build()));
+        $this->assertFalse($caster->supports(new PropertyPlanBuilder(type: 'array')->build()));
+
+        $itemPlan = new PropertyPlanBuilder(isStringLike: true)->build()
+            ->withCasterChain(new TrimCaster(new ScalarCaster()));
+        $this->assertFalse($caster->supports(new PropertyPlanBuilder(type: 'array', itemPlan: $itemPlan)->build()));
+    }
+
+    public function testAssociativeArrayPassesAsIs(): void
+    {
+        $value = ['a' => ['b' => 1], 'c' => [1, 2, 3]];
+
+        $result = new FreeFormCaster()->cast(RawValue::of($value), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame($value, $result->value());
+    }
+
+    public function testListPassesAsIs(): void
+    {
+        $result = new FreeFormCaster()->cast(RawValue::of([1, 'two', null]), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame([1, 'two', null], $result->value());
+    }
+
+    public function testStringIsTypeError(): void
+    {
+        $result = new FreeFormCaster()->cast(RawValue::of('x'), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.array', $result->reasons()[0]->code);
+    }
+
+    public function testIntIsTypeError(): void
+    {
+        $result = new FreeFormCaster()->cast(RawValue::of(5), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.array', $result->reasons()[0]->code);
+    }
+
+    private function plan(): \Leads\Core\Payload\Plan\PropertyPlan
+    {
+        return new PropertyPlanBuilder(
+            name: 'options',
+            key: 'options',
+            sourceKey: 'body',
+            pointer: 'body/options',
+            type: 'array',
+            freeForm: true,
+        )->build();
+    }
+}

--- a/tests/Unit/Payload/Cast/IntCasterTest.php
+++ b/tests/Unit/Payload/Cast/IntCasterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class IntCasterTest extends TestCase
+{
+    #[DataProvider('cases')]
+    public function testCast(mixed $input, bool $ok, mixed $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'int')->build();
+
+        $result = new IntCaster()->cast(RawValue::of($input), $plan);
+
+        $this->assertSame($ok, $result->isOk());
+        if ($ok) {
+            $this->assertSame($expected, $result->value());
+        } else {
+            $this->assertSame($expected, $result->reasons()[0]->code);
+        }
+    }
+
+    public static function cases(): iterable
+    {
+        yield 'int' => [42, true, 42];
+        yield 'numeric string' => ['42', true, 42];
+        yield 'negative string' => ['-7', true, -7];
+        yield 'empty string rejected' => ['', false, 'type.int'];
+        yield 'null rejected' => [null, false, 'type.int'];
+        yield 'float string rejected' => ['5.5', false, 'type.int'];
+        yield 'letters rejected' => ['abc', false, 'type.int'];
+        yield 'bool rejected' => [true, false, 'type.int'];
+        yield 'float rejected' => [5.5, false, 'type.int'];
+        yield 'array rejected' => [[1], false, 'type.int'];
+    }
+}

--- a/tests/Unit/Payload/Cast/ScalarCasterTest.php
+++ b/tests/Unit/Payload/Cast/ScalarCasterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ScalarCasterTest extends TestCase
+{
+    #[DataProvider('stringCases')]
+    public function testCastString(mixed $input, bool $ok, mixed $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'string')->build();
+
+        $result = new ScalarCaster()->cast(RawValue::of($input), $plan);
+
+        $this->assertSame($ok, $result->isOk());
+        if ($ok) {
+            $this->assertSame($expected, $result->value());
+        } else {
+            $this->assertSame($expected, $result->reasons()[0]->code);
+        }
+    }
+
+    public static function stringCases(): iterable
+    {
+        yield 'plain string' => ['john', true, 'john'];
+        yield 'int to string' => [5, true, '5'];
+        yield 'float to string' => [5.5, true, '5.5'];
+        yield 'empty string kept' => ['', true, ''];
+        yield 'array rejected' => [['a'], false, 'type.string'];
+        yield 'bool rejected' => [true, false, 'type.string'];
+        yield 'null rejected' => [null, false, 'type.string'];
+    }
+
+    #[DataProvider('floatCases')]
+    public function testCastFloat(mixed $input, bool $ok, mixed $expected): void
+    {
+        $plan = new PropertyPlanBuilder(type: 'float')->build();
+
+        $result = new ScalarCaster()->cast(RawValue::of($input), $plan);
+
+        $this->assertSame($ok, $result->isOk());
+        if ($ok) {
+            $this->assertSame($expected, $result->value());
+        } else {
+            $this->assertSame($expected, $result->reasons()[0]->code);
+        }
+    }
+
+    public static function floatCases(): iterable
+    {
+        yield 'float' => [5.5, true, 5.5];
+        yield 'int to float' => [5, true, 5.0];
+        yield 'numeric string' => ['5.5', true, 5.5];
+        yield 'empty string rejected' => ['', false, 'type.float'];
+        yield 'letters rejected' => ['abc', false, 'type.float'];
+        yield 'array rejected' => [[1.0], false, 'type.float'];
+    }
+
+    public function testSupportsStringAndFloatOnly(): void
+    {
+        $caster = new ScalarCaster();
+
+        $this->assertTrue($caster->supports(new PropertyPlanBuilder(type: 'string')->build()));
+        $this->assertTrue($caster->supports(new PropertyPlanBuilder(type: 'float')->build()));
+        $this->assertFalse($caster->supports(new PropertyPlanBuilder(type: 'int')->build()));
+        $this->assertFalse($caster->supports(new PropertyPlanBuilder(type: 'bool')->build()));
+    }
+}

--- a/tests/Unit/Payload/Cast/ScalarCollectionCasterTest.php
+++ b/tests/Unit/Payload/Cast/ScalarCollectionCasterTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Cast;
+
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Payload\RawValue;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class ScalarCollectionCasterTest extends TestCase
+{
+    public function testSupportsOnlyPlansWithItemPlan(): void
+    {
+        $caster = new ScalarCollectionCaster();
+
+        $this->assertTrue($caster->supports($this->plan()));
+        $this->assertFalse($caster->supports(new PropertyPlanBuilder(type: 'array')->build()));
+    }
+
+    public function testItemsAreCastAndTrimmedIndividually(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of([' abc ', 'def', 5]), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(['abc', 'def', '5'], $result->value());
+    }
+
+    public function testEmptyListIsOk(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of([]), $this->plan());
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame([], $result->value());
+    }
+
+    public function testAssociativeArrayIsCollectionTypeError(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of(['a' => 'b']), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.collection', $result->reasons()[0]->code);
+    }
+
+    public function testScalarInsteadOfListIsCollectionTypeError(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of('abc'), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.collection', $result->reasons()[0]->code);
+    }
+
+    public function testOversizedListIsRejectedBeforeCastingItems(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of(['a', 'b', 'c']), $this->plan(maxItems: 2));
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('collection.too_many', $result->reasons()[0]->code);
+    }
+
+    public function testBrokenItemIsNestedByIndex(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of(['ok', ['broken'], 'ok']), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.string', $result->reasons()[0]->code);
+        $this->assertSame('1', $result->reasons()[0]->path);
+    }
+
+    public function testFailFastOnTwoBrokenItemsReportsSingleReason(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of([['broken'], ['also-broken']]), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertCount(1, $result->reasons());
+        $this->assertSame('0', $result->reasons()[0]->path);
+    }
+
+    public function testNullItemIsTypeError(): void
+    {
+        $result = new ScalarCollectionCaster()->cast(RawValue::of([null]), $this->plan());
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('type.string', $result->reasons()[0]->code);
+        $this->assertSame('0', $result->reasons()[0]->path);
+    }
+
+    private function plan(int $maxItems = 1000): PropertyPlan
+    {
+        $itemPlan = new PropertyPlanBuilder(
+            name: 'sourcesIds[]',
+            key: '',
+            sourceKey: '',
+            pointer: '',
+            isStringLike: true,
+        )->build();
+
+        return new PropertyPlanBuilder(
+            name: 'sourcesIds',
+            key: 'sourcesIds',
+            sourceKey: 'body',
+            pointer: 'body/sourcesIds',
+            type: 'array',
+            itemPlan: $itemPlan->withCasterChain(new TrimCaster(new ScalarCaster())),
+            maxItems: $maxItems,
+        )->build();
+    }
+}

--- a/tests/Unit/Payload/Error/PayloadExceptionListenerTest.php
+++ b/tests/Unit/Payload/Error/PayloadExceptionListenerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Error;
+
+use Leads\Core\Payload\Error\PayloadExceptionListener;
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\Error\StateConflictException;
+use Leads\Core\Payload\Error\Violation;
+use Leads\Core\Payload\Error\ViolationList;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class PayloadExceptionListenerTest extends TestCase
+{
+    public function testRendersValidationProblemJson(): void
+    {
+        $exception = PayloadViolationException::fromCast(new ViolationList([
+            new Violation('body/items/0/quantity', 'Expected an integer.', 'type.int'),
+        ]));
+
+        $event = $this->event($exception);
+
+        new PayloadExceptionListener()->onKernelException($event);
+
+        $response = $event->getResponse();
+        $this->assertNotNull($response);
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertSame('application/problem+json', $response->headers->get('Content-Type'));
+
+        $body = json_decode((string)$response->getContent(), true);
+        $this->assertSame('/errors/validation', $body['type']);
+        $this->assertSame('Request payload is invalid', $body['title']);
+        $this->assertSame(400, $body['status']);
+        $this->assertIsList($body['errors']);
+        $this->assertSame(
+            ['pointer' => 'body/items/0/quantity', 'detail' => 'Expected an integer.', 'code' => 'type.int'],
+            $body['errors'][0],
+        );
+    }
+
+    public function testRendersConflictWith409(): void
+    {
+        $event = $this->event(new StateConflictException('body/email', 'Email is already taken.'));
+
+        new PayloadExceptionListener()->onKernelException($event);
+
+        $response = $event->getResponse();
+        $this->assertNotNull($response);
+        $this->assertSame(409, $response->getStatusCode());
+
+        $body = json_decode((string)$response->getContent(), true);
+        $this->assertSame('body/email', $body['errors'][0]['pointer']);
+        $this->assertSame('state.conflict', $body['errors'][0]['code']);
+    }
+
+    public function testValidatorViolationRendersAs400(): void
+    {
+        $exception = PayloadViolationException::fromValidator(new ViolationList([
+            new Violation('query/toDate', 'fromDate must be before or equal to toDate.', 'validation.failed'),
+        ]));
+
+        $event = $this->event($exception);
+
+        new PayloadExceptionListener()->onKernelException($event);
+
+        $this->assertNotNull($event->getResponse());
+        $this->assertSame(400, $event->getResponse()->getStatusCode());
+    }
+
+    public function testIgnoresForeignExceptions(): void
+    {
+        $event = $this->event(new \RuntimeException('unrelated'));
+
+        new PayloadExceptionListener()->onKernelException($event);
+
+        $this->assertNull($event->getResponse());
+    }
+
+    private function event(\Throwable $exception): ExceptionEvent
+    {
+        return new ExceptionEvent(
+            $this->createStub(HttpKernelInterface::class),
+            Request::create('/sample'),
+            HttpKernelInterface::MAIN_REQUEST,
+            $exception,
+        );
+    }
+}

--- a/tests/Unit/Payload/Error/PropertyPathConverterTest.php
+++ b/tests/Unit/Payload/Error/PropertyPathConverterTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Error;
+
+use Leads\Core\Payload\Error\PropertyPathConverter;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PropertyPathConverterTest extends TestCase
+{
+    #[DataProvider('cases')]
+    public function testConvertsValidatorNotationToPointer(string $propertyPath, string $expected): void
+    {
+        $this->assertSame($expected, PropertyPathConverter::toPointer($propertyPath));
+    }
+
+    public static function cases(): iterable
+    {
+        yield 'collection element' => ['items[0].quantity', 'items/0/quantity'];
+        yield 'nested object' => ['address.city', 'address/city'];
+        yield 'plain property' => ['toDate', 'toDate'];
+        yield 'deep nesting' => ['orders[2].items[0].sku', 'orders/2/items/0/sku'];
+    }
+}

--- a/tests/Unit/Payload/Error/ReasonTest.php
+++ b/tests/Unit/Payload/Error/ReasonTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Error;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Error\Violation;
+use PHPUnit\Framework\TestCase;
+
+final class ReasonTest extends TestCase
+{
+    public function testNestPrependsSegmentToEmptyPath(): void
+    {
+        $reason = new Reason('type.int', 'Expected an integer.');
+
+        $nested = $reason->nest('quantity');
+
+        $this->assertSame('quantity', $nested->path);
+    }
+
+    public function testNestAccumulatesPathBottomUp(): void
+    {
+        $reason = new Reason('type.int', 'Expected an integer.');
+
+        $nested = $reason->nest('quantity')->nest(0)->nest('body/items');
+
+        $this->assertSame('body/items/0/quantity', $nested->path);
+    }
+
+    public function testNestKeepsCodeDetailAndParams(): void
+    {
+        $reason = new Reason('enum.unknown', 'Unknown value.', ['allowed' => 'a, b']);
+
+        $nested = $reason->nest('sortBy');
+
+        $this->assertSame('enum.unknown', $nested->code);
+        $this->assertSame('Unknown value.', $nested->detail);
+        $this->assertSame(['allowed' => 'a, b'], $nested->params);
+    }
+
+    public function testViolationFromReasonUsesPathAsPointer(): void
+    {
+        $reason = new Reason('type.int', 'Expected an integer.', path: 'body/items/0/quantity');
+
+        $violation = Violation::fromReason($reason);
+
+        $this->assertSame('body/items/0/quantity', $violation->pointer);
+        $this->assertSame('Expected an integer.', $violation->detail);
+        $this->assertSame('type.int', $violation->code);
+    }
+}

--- a/tests/Unit/Payload/ObjectAssemblerTest.php
+++ b/tests/Unit/Payload/ObjectAssemblerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Tests\Fixture\Payload\SampleAddress;
+use PHPUnit\Framework\TestCase;
+
+final class ObjectAssemblerTest extends TestCase
+{
+    public function testAssemblesNestedPlanFromArray(): void
+    {
+        $plan = $this->factory()->build(SampleAddress::class, nested: true);
+
+        $result = new ObjectAssembler()->assemble($plan, ['city' => 'Yerevan', 'zip' => '0010']);
+
+        $this->assertTrue($result->isOk());
+        $address = $result->value();
+        $this->assertInstanceOf(SampleAddress::class, $address);
+        $this->assertSame('Yerevan', $address->city);
+    }
+
+    public function testMissingRequiredFieldGivesRequiredReasonWithPropertyPointer(): void
+    {
+        $plan = $this->factory()->build(SampleAddress::class, nested: true);
+
+        $result = new ObjectAssembler()->assemble($plan, ['city' => 'Yerevan']);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('required', $result->reasons()[0]->code);
+        $this->assertSame('zip', $result->reasons()[0]->path);
+    }
+
+    public function testExcessiveDepthIsRejected(): void
+    {
+        $plan = $this->factory()->build(SampleAddress::class, nested: true);
+
+        $result = new ObjectAssembler()->assemble($plan, ['city' => 'Yerevan', 'zip' => '0010'], depth: 33);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame('depth.exceeded', $result->reasons()[0]->code);
+    }
+
+    private function factory(): PlanFactory
+    {
+        return new PlanFactory(new CasterRegistry([new ScalarCaster(), new IntCaster()]));
+    }
+}

--- a/tests/Unit/Payload/PayloadMapperFreeFormTest.php
+++ b/tests/Unit/Payload/PayloadMapperFreeFormTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\FreeFormCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleFreeFormRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadMapperFreeFormTest extends TestCase
+{
+    public function testNestedStructurePassesVerbatim(): void
+    {
+        $options = ['a' => ['b' => 1], 'c' => [1, 2, ['d' => null]]];
+
+        $dto = $this->map(['options' => $options]);
+
+        $this->assertSame($options, $dto->options);
+    }
+
+    public function testScalarInsteadOfArrayIsTypeError(): void
+    {
+        try {
+            $this->map(['options' => 'x']);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame(Response::HTTP_BAD_REQUEST, $payloadViolationException->getStatusCode());
+            $this->assertSame('type.array', $violation->code);
+            $this->assertSame('body/options', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testNullForNullableFreeFormStaysNull(): void
+    {
+        $dto = $this->map(['meta' => null]);
+
+        $this->assertNull($dto->meta);
+    }
+
+    public function testMissingKeysFallBackToDefaults(): void
+    {
+        $dto = $this->map([]);
+
+        $this->assertSame([], $dto->options);
+        $this->assertNull($dto->meta);
+    }
+
+    public function testValidatorConstraintsRunAfterMapping(): void
+    {
+        try {
+            $this->map(['options' => ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'f' => 6]]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame(Response::HTTP_BAD_REQUEST, $payloadViolationException->getStatusCode());
+            $this->assertSame('body/options', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    private function map(array $body): SampleFreeFormRequest
+    {
+        $request = Request::create(
+            uri: '/samples',
+            method: Request::METHOD_POST,
+            content: (string)json_encode($body),
+        );
+
+        return $this->mapper()->map(SampleFreeFormRequest::class, $request);
+    }
+
+    private function mapper(): PayloadMapper
+    {
+        $assembler = new ObjectAssembler();
+        $registry = new CasterRegistry([
+            new ScalarCaster(),
+            new IntCaster(),
+            new BoolCaster(),
+            new FreeFormCaster(),
+        ]);
+
+        return new PayloadMapper(
+            plans: new PlanFactory($registry),
+            assembler: $assembler,
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator(),
+            logger: new NullLogger(),
+        );
+    }
+}

--- a/tests/Unit/Payload/PayloadMapperNestedTest.php
+++ b/tests/Unit/Payload/PayloadMapperNestedTest.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\CollectionCaster;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\NestedObjectCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleAddress;
+use Leads\Core\Tests\Fixture\Payload\SampleItem;
+use Leads\Core\Tests\Fixture\Payload\SampleNestedRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadMapperNestedTest extends TestCase
+{
+    public function testNestedObjectAndCollectionAreAssembled(): void
+    {
+        $dto = $this->map([
+            'title' => 'order',
+            'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+            'items' => [
+                ['sku' => 'a-1', 'quantity' => 2],
+                ['sku' => 'b-2', 'quantity' => 5],
+            ],
+            'scheduledAt' => '2026-08-07 10:30:00',
+            'totalPrice' => '99.90',
+        ]);
+
+        $this->assertSame(99.9, $dto->totalPrice);
+        $this->assertSame('order', $dto->title);
+        $this->assertInstanceOf(SampleAddress::class, $dto->address);
+        $this->assertSame('Yerevan', $dto->address->city);
+        $this->assertCount(2, $dto->items);
+        $this->assertInstanceOf(SampleItem::class, $dto->items[0]);
+        $this->assertSame('a-1', $dto->items[0]->sku);
+        $this->assertSame(5, $dto->items[1]->quantity);
+        $this->assertNotNull($dto->scheduledAt);
+        $this->assertSame('2026-08-07 10:30:00', $dto->scheduledAt->format('Y-m-d H:i:s'));
+    }
+
+    public function testEmptyObjectGivesRequiredErrorsNotTypeObject(): void
+    {
+        try {
+            $this->map(['title' => 'order', 'address' => []]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('required', $violation->code);
+            $this->assertSame('body/address/city', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testBrokenCollectionItemPointsToElementField(): void
+    {
+        try {
+            $this->map([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => [
+                    ['sku' => 'a-1', 'quantity' => 2],
+                    ['sku' => 'b-2', 'quantity' => 'abc'],
+                ],
+            ]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame(Response::HTTP_BAD_REQUEST, $payloadViolationException->getStatusCode());
+            $this->assertSame('body/items/1/quantity', $violation->pointer);
+            $this->assertSame('type.int', $violation->code);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testNestedValidatorViolationUsesSamePointerNotation(): void
+    {
+        try {
+            $this->map([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => [
+                    ['sku' => 'a-1', 'quantity' => -5],
+                ],
+            ]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame(Response::HTTP_BAD_REQUEST, $payloadViolationException->getStatusCode());
+            $this->assertSame('body/items/0/quantity', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testNonObjectNestedValueIsTypeError(): void
+    {
+        try {
+            $this->map(['title' => 'order', 'address' => 'not-an-object']);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('type.object', $violation->code);
+            $this->assertSame('body/address', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testAssociativeArrayInsteadOfListIsTypeError(): void
+    {
+        try {
+            $this->map([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => ['a' => ['sku' => 'a-1', 'quantity' => 2]],
+            ]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('type.collection', $violation->code);
+            $this->assertSame('body/items', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testOversizedCollectionIsRejectedBeforeConstructingItems(): void
+    {
+        $items = [];
+        for ($i = 0; $i <= 1000; ++$i) {
+            $items[] = ['sku' => 'sku-' . $i, 'quantity' => 1];
+        }
+
+        try {
+            $this->map([
+                'title' => 'order',
+                'address' => ['city' => 'Yerevan', 'zip' => '0010'],
+                'items' => $items,
+            ]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('collection.too_many', $violation->code);
+            $this->assertSame('body/items', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testMissingRequiredFieldsAccumulateWithinObject(): void
+    {
+        try {
+            // required — не «битое» поле: отсутствующие поля объекта перечисляются все,
+            // fail-fast (break) относится только к ошибкам каста.
+            $this->map(['title' => 'order', 'address' => ['unexpected' => 1]]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violations = $payloadViolationException->getViolations()->all();
+            $this->assertCount(2, $violations);
+            $this->assertSame('body/address/city', $violations[0]->pointer);
+            $this->assertSame('body/address/zip', $violations[1]->pointer);
+            $this->assertSame('required', $violations[0]->code);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testFailFastOnTwoCastBrokenNestedFieldsReportsSingleError(): void
+    {
+        try {
+            $this->map([
+                'title' => 'order',
+                'address' => ['city' => ['broken'], 'zip' => ['also-broken']],
+            ]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $this->assertCount(1, $payloadViolationException->getViolations());
+            $this->assertSame('body/address/city', $payloadViolationException->getViolations()->all()[0]->pointer);
+            $this->assertSame('type.string', $payloadViolationException->getViolations()->all()[0]->code);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    private function map(array $body): SampleNestedRequest
+    {
+        $request = Request::create(
+            uri: '/orders',
+            method: Request::METHOD_POST,
+            content: (string)json_encode($body),
+        );
+
+        return $this->mapper()->map(SampleNestedRequest::class, $request);
+    }
+
+    private function mapper(): PayloadMapper
+    {
+        $assembler = new ObjectAssembler();
+
+        // Ленивое замыкание реестра — как tagged_iterator в контейнере: Nested/Collection
+        // кастеры зависят от фабрики планов, которая зависит от реестра.
+        $casters = new \ArrayObject();
+        $registry = new CasterRegistry($casters);
+        $factory = new PlanFactory($registry);
+
+        $casters->append(new ScalarCaster());
+        $casters->append(new IntCaster());
+        $casters->append(new BoolCaster());
+        $casters->append(new EnumCaster());
+        $casters->append(new DateCaster());
+        $casters->append(new NestedObjectCaster($factory, $assembler));
+        $casters->append(new CollectionCaster($factory, $assembler));
+        $casters->append(new ScalarCollectionCaster());
+
+        return new PayloadMapper(
+            plans: $factory,
+            assembler: $assembler,
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator(),
+            logger: new NullLogger(),
+        );
+    }
+}

--- a/tests/Unit/Payload/PayloadMapperScalarCollectionTest.php
+++ b/tests/Unit/Payload/PayloadMapperScalarCollectionTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\CollectionCaster;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\NestedObjectCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleScalarCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadMapperScalarCollectionTest extends TestCase
+{
+    public function testScalarCollectionsAreCastPerItem(): void
+    {
+        $dto = $this->map([
+            'sourcesIds' => [' abc ', 'def', 5],
+            'counts' => ['5', 7],
+            'sorts' => ['CREATEDAT', 'lastName'],
+            'dates' => ['2026-08-07'],
+            'tags' => ['x'],
+        ]);
+
+        $this->assertSame(['abc', 'def', '5'], $dto->sourcesIds);
+        $this->assertSame([5, 7], $dto->counts);
+        $this->assertSame([SampleSortField::CreatedAt, SampleSortField::LastName], $dto->sorts);
+        $this->assertCount(1, $dto->dates);
+        $this->assertSame('2026-08-07', $dto->dates[0]->format('Y-m-d'));
+        $this->assertSame(['x'], $dto->tags);
+    }
+
+    public function testMissingKeysFallBackToDefaults(): void
+    {
+        $dto = $this->map([]);
+
+        $this->assertSame([], $dto->sourcesIds);
+        $this->assertSame([], $dto->counts);
+        $this->assertNull($dto->tags);
+    }
+
+    public function testNullForNullableCollectionStaysNull(): void
+    {
+        $dto = $this->map(['tags' => null]);
+
+        $this->assertNull($dto->tags);
+    }
+
+    public function testBrokenItemPointsToElementIndex(): void
+    {
+        try {
+            $this->map(['sourcesIds' => ['a', 'b', ['broken']]]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('type.string', $violation->code);
+            $this->assertSame('body/sourcesIds/2', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testAssociativeArrayInsteadOfListIsTypeError(): void
+    {
+        try {
+            $this->map(['sourcesIds' => ['a' => 'b']]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('type.collection', $violation->code);
+            $this->assertSame('body/sourcesIds', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testUnknownEnumItemPointsToElementIndex(): void
+    {
+        try {
+            $this->map(['sorts' => ['createdAt', 'password']]);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $violation = $payloadViolationException->getViolations()->all()[0];
+            $this->assertSame('enum.unknown', $violation->code);
+            $this->assertSame('body/sorts/1', $violation->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    private function map(array $body): SampleScalarCollectionRequest
+    {
+        $request = Request::create(
+            uri: '/samples',
+            method: Request::METHOD_POST,
+            content: (string)json_encode($body),
+        );
+
+        return $this->mapper()->map(SampleScalarCollectionRequest::class, $request);
+    }
+
+    private function mapper(): PayloadMapper
+    {
+        $assembler = new ObjectAssembler();
+
+        // Ленивое замыкание реестра — как tagged_iterator в контейнере: Nested/Collection
+        // кастеры зависят от фабрики планов, которая зависит от реестра.
+        $casters = new \ArrayObject();
+        $registry = new CasterRegistry($casters);
+        $factory = new PlanFactory($registry);
+
+        $casters->append(new ScalarCaster());
+        $casters->append(new IntCaster());
+        $casters->append(new BoolCaster());
+        $casters->append(new EnumCaster());
+        $casters->append(new DateCaster());
+        $casters->append(new NestedObjectCaster($factory, $assembler));
+        $casters->append(new CollectionCaster($factory, $assembler));
+        $casters->append(new ScalarCollectionCaster());
+
+        return new PayloadMapper(
+            plans: $factory,
+            assembler: $assembler,
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator(),
+            logger: new NullLogger(),
+        );
+    }
+}

--- a/tests/Unit/Payload/PayloadMapperSplitTest.php
+++ b/tests/Unit/Payload/PayloadMapperSplitTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\CollectionCaster;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\FreeFormCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\NestedObjectCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleSplitRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadMapperSplitTest extends TestCase
+{
+    public function testCsvStringBecomesList(): void
+    {
+        $dto = $this->map(['ids' => 'a,b,c']);
+
+        $this->assertSame(['a', 'b', 'c'], $dto->ids);
+    }
+
+    public function testItemsAreTrimmed(): void
+    {
+        $dto = $this->map(['ids' => 'a, b , c']);
+
+        $this->assertSame(['a', 'b', 'c'], $dto->ids);
+    }
+
+    public function testEmptyStringIsEmptyList(): void
+    {
+        $dto = $this->map(['ids' => '']);
+
+        $this->assertSame([], $dto->ids);
+    }
+
+    public function testRealListSyntaxStillWorks(): void
+    {
+        $dto = $this->map(['ids' => ['a', 'b']]);
+
+        $this->assertSame(['a', 'b'], $dto->ids);
+    }
+
+    public function testCsvInsideNestedFilterIsSplit(): void
+    {
+        $dto = $this->map(['filter' => ['ids' => 'a,b,c']]);
+
+        $this->assertNotNull($dto->filter);
+        $this->assertSame(['a', 'b', 'c'], $dto->filter->ids);
+    }
+
+    public function testCustomSeparatorWithIntItems(): void
+    {
+        $dto = $this->map(['counts' => '1|2']);
+
+        $this->assertSame([1, 2], $dto->counts);
+    }
+
+    public function testMissingKeysFallBackToDefaults(): void
+    {
+        $dto = $this->map([]);
+
+        $this->assertSame([], $dto->ids);
+        $this->assertSame([], $dto->counts);
+        $this->assertNull($dto->tags);
+        $this->assertNull($dto->filter);
+    }
+
+    private function map(array $query): SampleSplitRequest
+    {
+        $request = Request::create(uri: '/samples', method: Request::METHOD_GET, parameters: $query);
+
+        return $this->mapper()->map(SampleSplitRequest::class, $request);
+    }
+
+    private function mapper(): PayloadMapper
+    {
+        $assembler = new ObjectAssembler();
+
+        // Ленивое замыкание реестра — как tagged_iterator в контейнере: Nested/Collection
+        // кастеры зависят от фабрики планов, которая зависит от реестра.
+        $casters = new \ArrayObject();
+        $registry = new CasterRegistry($casters);
+        $factory = new PlanFactory($registry);
+
+        $casters->append(new ScalarCaster());
+        $casters->append(new IntCaster());
+        $casters->append(new BoolCaster());
+        $casters->append(new EnumCaster());
+        $casters->append(new DateCaster());
+        $casters->append(new NestedObjectCaster($factory, $assembler));
+        $casters->append(new CollectionCaster($factory, $assembler));
+        $casters->append(new ScalarCollectionCaster());
+        $casters->append(new FreeFormCaster());
+
+        return new PayloadMapper(
+            plans: $factory,
+            assembler: $assembler,
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator(),
+            logger: new NullLogger(),
+        );
+    }
+}

--- a/tests/Unit/Payload/PayloadMapperTest.php
+++ b/tests/Unit/Payload/PayloadMapperTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Error\MalformedPayloadException;
+use Leads\Core\Payload\Error\PayloadExceptionListener;
+use Leads\Core\Payload\Error\PayloadTooLargeException;
+use Leads\Core\Payload\Error\PayloadViolationException;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ExceptionEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadMapperTest extends TestCase
+{
+    #[DataProvider('successCases')]
+    public function testSuccessfulMapping(string $query, SampleSortField $sortBy, int $limit, ?string $email): void
+    {
+        $dto = $this->map($query);
+
+        $this->assertSame($sortBy, $dto->sortBy);
+        $this->assertSame($limit, $dto->limit);
+        $this->assertSame($email, $dto->email);
+    }
+
+    public static function successCases(): iterable
+    {
+        yield 'defaults' => ['', SampleSortField::CreatedAt, 20, null];
+        yield 'case insensitive enum' => ['sortBy=LASTNAME', SampleSortField::LastName, 20, null];
+        yield 'unknown enum value falls back' => ['sortBy=password', SampleSortField::CreatedAt, 20, null];
+        yield 'limit clamped down' => ['limit=500', SampleSortField::CreatedAt, 100, null];
+        yield 'limit clamped up' => ['limit=0', SampleSortField::CreatedAt, 1, null];
+        yield 'blank email is null' => ['email=', SampleSortField::CreatedAt, 20, null];
+        yield 'spaces-only email is null' => ['email=%20%20', SampleSortField::CreatedAt, 20, null];
+        yield 'unicode padding trimmed' => [
+            'email=%C2%A0john%40x.com%C2%A0',
+            SampleSortField::CreatedAt,
+            20,
+            'john@x.com',
+        ];
+    }
+
+    public function testDateIsParsedWithZeroedTime(): void
+    {
+        $dto = $this->map('fromDate=2026-08-07');
+
+        $this->assertNotNull($dto->fromDate);
+        $this->assertSame('2026-08-07 00:00:00', $dto->fromDate->format('Y-m-d H:i:s'));
+    }
+
+    public function testBoolAndPathAndHeaderSources(): void
+    {
+        $request = Request::create('/sample?archived=true');
+        $request->attributes->set('_route_params', ['projectId' => 'uuid-42']);
+        $request->headers->set('X-Request-Source', 'mobile');
+
+        $dto = $this->mapper()->map(SampleRequest::class, $request);
+
+        $this->assertTrue($dto->archived);
+        $this->assertSame('uuid-42', $dto->projectId);
+        $this->assertSame('mobile', $dto->requestSource);
+    }
+
+    #[DataProvider('errorCases')]
+    public function testMappingErrors(string $query, string $pointer, int $status): void
+    {
+        try {
+            $this->map($query);
+        } catch (PayloadViolationException $payloadViolationException) {
+            $this->assertSame($status, $payloadViolationException->getStatusCode());
+            $this->assertCount(1, $payloadViolationException->getViolations());
+            $this->assertSame($pointer, $payloadViolationException->getViolations()->all()[0]->pointer);
+
+            return;
+        }
+
+        $this->fail(sprintf('Expected PayloadViolationException for query "%s".', $query));
+    }
+
+    public static function errorCases(): iterable
+    {
+        yield 'wrong date format' => ['fromDate=07.08.2026', 'query/fromDate', Response::HTTP_BAD_REQUEST];
+        yield 'impossible date' => ['fromDate=2026-02-31', 'query/fromDate', Response::HTTP_BAD_REQUEST];
+        yield 'inverted range' => [
+            'fromDate=2026-08-07&toDate=2026-08-01',
+            'query/toDate',
+            Response::HTTP_BAD_REQUEST,
+        ];
+        yield 'array instead of scalar not restored by fallback' => [
+            'sortBy%5B%5D=id&sortBy%5B%5D=email',
+            'query/sortBy',
+            Response::HTTP_BAD_REQUEST,
+        ];
+        yield 'bad limit' => ['limit=abc', 'query/limit', Response::HTTP_BAD_REQUEST];
+    }
+
+    public function testFailFastReportsOnlyFirstBrokenFieldInConstructorOrder(): void
+    {
+        try {
+            $this->map('limit=abc&fromDate=07.08.2026');
+        } catch (PayloadViolationException $payloadViolationException) {
+            $this->assertCount(1, $payloadViolationException->getViolations());
+            $this->assertSame('query/limit', $payloadViolationException->getViolations()->all()[0]->pointer);
+
+            return;
+        }
+
+        $this->fail('Expected PayloadViolationException.');
+    }
+
+    public function testOversizedBodyIsRejectedWith413(): void
+    {
+        $request = Request::create(
+            uri: '/sample',
+            method: Request::METHOD_POST,
+            content: '{"note":"' . str_repeat('x', 3000) . '"}',
+        );
+
+        $this->expectException(PayloadTooLargeException::class);
+
+        $this->mapper()->map(SampleRequest::class, $request);
+    }
+
+    public function testMalformedBodyIsRejectedWith400(): void
+    {
+        $request = Request::create(uri: '/sample', method: Request::METHOD_POST, content: '{"note": broken}');
+
+        $this->expectException(MalformedPayloadException::class);
+
+        $this->mapper()->map(SampleRequest::class, $request);
+    }
+
+    public function testUnknownBodyFieldIsLoggedByNameWithoutValue(): void
+    {
+        $logger = new RecordingLogger();
+        $request = Request::create(
+            uri: '/sample',
+            method: Request::METHOD_POST,
+            content: '{"password": "hunter2"}',
+        );
+        $request->attributes->set('_route', 'sample_route');
+
+        $this->mapper($logger)->map(SampleRequest::class, $request);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('payload.unknown_fields', $logger->records[0]['message']);
+        $this->assertSame(['password'], $logger->records[0]['context']['fields']);
+        $this->assertSame('sample_route', $logger->records[0]['context']['route']);
+        $this->assertStringNotContainsString('hunter2', (string)json_encode($logger->records[0]));
+    }
+
+    public function testSecretFromRequestNeverAppearsInErrorResponse(): void
+    {
+        $logger = new RecordingLogger();
+        $request = Request::create(
+            uri: '/sample?limit=abc',
+            method: Request::METHOD_POST,
+            content: '{"password": "hunter2"}',
+        );
+
+        try {
+            $this->mapper($logger)->map(SampleRequest::class, $request);
+            $this->fail('Expected PayloadViolationException.');
+        } catch (PayloadViolationException $payloadViolationException) {
+            $event = new ExceptionEvent(
+                $this->createStub(HttpKernelInterface::class),
+                $request,
+                HttpKernelInterface::MAIN_REQUEST,
+                $payloadViolationException,
+            );
+            new PayloadExceptionListener()->onKernelException($event);
+
+            $this->assertNotNull($event->getResponse());
+            $this->assertStringNotContainsString('hunter2', (string)$event->getResponse()->getContent());
+            $this->assertStringNotContainsString('hunter2', (string)json_encode($logger->records));
+        }
+    }
+
+    public function testKnownQueryIsNotReportedAsUnknown(): void
+    {
+        $logger = new RecordingLogger();
+
+        $this->mapper($logger)->map(SampleRequest::class, Request::create('/sample?limit=5&utm_source=newsletter'));
+
+        $this->assertSame([], $logger->records);
+    }
+
+    private function map(string $query): SampleRequest
+    {
+        return $this->mapper()->map(SampleRequest::class, Request::create('/sample?' . $query));
+    }
+
+    private function mapper(?LoggerInterface $logger = null): PayloadMapper
+    {
+        $registry = new CasterRegistry([
+            new ScalarCaster(),
+            new IntCaster(),
+            new BoolCaster(),
+            new EnumCaster(),
+            new DateCaster(),
+        ]);
+
+        $validator = Validation::createValidatorBuilder()
+            ->enableAttributeMapping()
+            ->getValidator();
+
+        return new PayloadMapper(
+            plans: new PlanFactory($registry),
+            assembler: new ObjectAssembler(),
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: $validator,
+            logger: $logger ?? new NullLogger(),
+        );
+    }
+}

--- a/tests/Unit/Payload/Plan/PlanFactoryTest.php
+++ b/tests/Unit/Payload/Plan/PlanFactoryTest.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Plan;
+
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\CollectionCaster;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\Decorator\ClampCaster;
+use Leads\Core\Payload\Cast\Decorator\FallbackCaster;
+use Leads\Core\Payload\Cast\Decorator\NullableCaster;
+use Leads\Core\Payload\Cast\Decorator\SplitCaster;
+use Leads\Core\Payload\Cast\Decorator\TrimCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\FreeFormCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\NestedObjectCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\Cast\ScalarCollectionCaster;
+use Leads\Core\Payload\Cast\ValueCaster;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Plan\PropertyPlan;
+use Leads\Core\Tests\Fixture\Payload\Invalid\AddressWithSourceAttribute;
+use Leads\Core\Tests\Fixture\Payload\Invalid\FreeFormOnNonArrayRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\FreeFormWithItemTypeRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\MaxItemsBelowOneRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\MaxItemsOnNonCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\MissingSourceRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\MultipleSourcesRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\NestedWithoutValidRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\NullableItemCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\PlainArrayRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\SplitEmptySeparatorRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\SplitOnNonCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\UnknownTypeRequest;
+use Leads\Core\Tests\Fixture\Payload\Invalid\UnsupportedItemCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleFreeFormRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleMaxItemsRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleScalarCollectionRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use Leads\Core\Tests\Fixture\Payload\SampleSplitRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class PlanFactoryTest extends TestCase
+{
+    public function testSampleRequestPlanIsBuilt(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $this->assertSame(SampleRequest::class, $plan->class);
+        $this->assertSame(2048, $plan->maxBodyBytes);
+        $this->assertSame([], $plan->bodyKeys);
+        $this->assertCount(9, $plan->properties);
+    }
+
+    public function testPointerMapUsesSourcePrefixedPointers(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $this->assertSame('query/toDate', $plan->pointerMap['toDate']);
+        $this->assertSame('query/limit', $plan->pointerMap['limit']);
+        $this->assertSame('path/projectId', $plan->pointerMap['projectId']);
+        $this->assertSame('header/X-Request-Source', $plan->pointerMap['requestSource']);
+    }
+
+    public function testHeaderPropertyUsesHeaderNameAsKey(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $requestSource = $this->property($plan->properties, 'requestSource');
+
+        $this->assertSame('X-Request-Source', $requestSource->key);
+        $this->assertSame('header', $requestSource->sourceKey);
+    }
+
+    public function testEnumPropertyChainIsFallbackAroundEnum(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $chain = $this->property($plan->properties, 'sortBy')->casterChain;
+
+        $this->assertInstanceOf(FallbackCaster::class, $chain);
+        $this->assertInstanceOf(EnumCaster::class, $this->unwrap($chain));
+    }
+
+    public function testClampedIntChainIsClampAroundInt(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $chain = $this->property($plan->properties, 'limit')->casterChain;
+
+        $this->assertInstanceOf(ClampCaster::class, $chain);
+        $this->assertInstanceOf(IntCaster::class, $this->unwrap($chain));
+    }
+
+    public function testNullableStringChainIsTrimAroundNullableAroundScalar(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $chain = $this->property($plan->properties, 'email')->casterChain;
+
+        $this->assertInstanceOf(TrimCaster::class, $chain);
+        $nullable = $this->unwrap($chain);
+        $this->assertInstanceOf(NullableCaster::class, $nullable);
+        $this->assertInstanceOf(ScalarCaster::class, $this->unwrap($nullable));
+    }
+
+    public function testDatePropertyResolvesToDateCaster(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $chain = $this->property($plan->properties, 'fromDate')->casterChain;
+
+        $this->assertInstanceOf(NullableCaster::class, $chain);
+        $this->assertInstanceOf(DateCaster::class, $this->unwrap($chain));
+    }
+
+    public function testNullableBoolResolvesToBoolCaster(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $chain = $this->property($plan->properties, 'archived')->casterChain;
+
+        $this->assertInstanceOf(NullableCaster::class, $chain);
+        $this->assertInstanceOf(BoolCaster::class, $this->unwrap($chain));
+    }
+
+    public function testFallbackKeepsEnumCase(): void
+    {
+        $plan = $this->factory()->build(SampleRequest::class);
+
+        $sortBy = $this->property($plan->properties, 'sortBy');
+
+        $this->assertTrue($sortBy->hasFallback);
+        $this->assertSame(SampleSortField::CreatedAt, $sortBy->fallback);
+        $this->assertTrue($sortBy->normalized);
+    }
+
+    public function testStringCollectionCompilesItemPlan(): void
+    {
+        $plan = $this->factory()->build(SampleScalarCollectionRequest::class);
+
+        $sourcesIds = $this->property($plan->properties, 'sourcesIds');
+
+        $this->assertNull($sourcesIds->itemClass);
+        $this->assertNotNull($sourcesIds->itemPlan);
+        $this->assertInstanceOf(ScalarCollectionCaster::class, $sourcesIds->casterChain);
+        $itemChain = $sourcesIds->itemPlan->casterChain;
+        $this->assertInstanceOf(TrimCaster::class, $itemChain);
+        $this->assertInstanceOf(ScalarCaster::class, $this->unwrap($itemChain));
+    }
+
+    public function testIntCollectionItemResolvesToIntCaster(): void
+    {
+        $plan = $this->factory()->build(SampleScalarCollectionRequest::class);
+
+        $counts = $this->property($plan->properties, 'counts');
+
+        $this->assertInstanceOf(IntCaster::class, $counts->itemPlan?->casterChain);
+    }
+
+    public function testEnumCollectionItemGoesToScalarPathWithNormalized(): void
+    {
+        $plan = $this->factory()->build(SampleScalarCollectionRequest::class);
+
+        $sorts = $this->property($plan->properties, 'sorts');
+
+        $this->assertNull($sorts->itemClass);
+        $this->assertSame(SampleSortField::class, $sorts->itemPlan?->enumClass);
+        $this->assertTrue($sorts->itemPlan->normalized);
+        $this->assertInstanceOf(EnumCaster::class, $sorts->itemPlan->casterChain);
+    }
+
+    public function testDateCollectionItemResolvesToDateCaster(): void
+    {
+        $plan = $this->factory()->build(SampleScalarCollectionRequest::class);
+
+        $dates = $this->property($plan->properties, 'dates');
+
+        $this->assertInstanceOf(DateCaster::class, $dates->itemPlan?->casterChain);
+    }
+
+    public function testNullableScalarCollectionWrapsChainInNullable(): void
+    {
+        $plan = $this->factory()->build(SampleScalarCollectionRequest::class);
+
+        $chain = $this->property($plan->properties, 'tags')->casterChain;
+
+        $this->assertInstanceOf(NullableCaster::class, $chain);
+        $this->assertInstanceOf(ScalarCollectionCaster::class, $this->unwrap($chain));
+    }
+
+    public function testSplitCollectionChainIsSplitAroundScalarCollection(): void
+    {
+        $plan = $this->factory()->build(SampleSplitRequest::class);
+
+        $ids = $this->property($plan->properties, 'ids');
+
+        $this->assertNotNull($ids->split);
+        $this->assertInstanceOf(SplitCaster::class, $ids->casterChain);
+        $this->assertInstanceOf(ScalarCollectionCaster::class, $this->unwrap($ids->casterChain));
+    }
+
+    public function testNullableSplitCollectionWrapsInNullable(): void
+    {
+        $plan = $this->factory()->build(SampleSplitRequest::class);
+
+        $chain = $this->property($plan->properties, 'tags')->casterChain;
+
+        $this->assertInstanceOf(NullableCaster::class, $chain);
+        $this->assertInstanceOf(SplitCaster::class, $this->unwrap($chain));
+    }
+
+    public function testFreeFormPlanResolvesToFreeFormCaster(): void
+    {
+        $plan = $this->factory()->build(SampleFreeFormRequest::class);
+
+        $options = $this->property($plan->properties, 'options');
+
+        $this->assertTrue($options->freeForm);
+        $this->assertNull($options->itemClass);
+        $this->assertNull($options->itemPlan);
+        $this->assertInstanceOf(FreeFormCaster::class, $options->casterChain);
+    }
+
+    public function testNullableFreeFormWrapsInNullable(): void
+    {
+        $plan = $this->factory()->build(SampleFreeFormRequest::class);
+
+        $chain = $this->property($plan->properties, 'meta')->casterChain;
+
+        $this->assertInstanceOf(NullableCaster::class, $chain);
+        $this->assertInstanceOf(FreeFormCaster::class, $this->unwrap($chain));
+    }
+
+    public function testMaxItemsOverridesCollectionLimit(): void
+    {
+        $plan = $this->factory()->build(SampleMaxItemsRequest::class);
+
+        $this->assertSame(5, $this->property($plan->properties, 'ids')->maxItems);
+        $this->assertSame(PropertyPlan::DEFAULT_MAX_ITEMS, $this->property($plan->properties, 'tags')->maxItems);
+    }
+
+    #[DataProvider('invalidFixtures')]
+    public function testConfigurationErrorsFailAtPlanBuild(string $class, bool $nested, string $messagePart): void
+    {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage($messagePart);
+
+        $this->factory()->build($class, $nested);
+    }
+
+    public static function invalidFixtures(): iterable
+    {
+        yield 'no source attribute' => [MissingSourceRequest::class, false, 'has no source attribute'];
+        yield 'unknown type' => [UnknownTypeRequest::class, false, 'No caster supports type'];
+        yield 'nested without Assert\Valid' => [NestedWithoutValidRequest::class, false, 'requires #[Assert\Valid]'];
+        yield 'source attribute on nested property' => [AddressWithSourceAttribute::class, true, 'meaningless'];
+        yield 'more than one source' => [MultipleSourcesRequest::class, false, 'more than one source'];
+        yield 'plain array without item type' => [PlainArrayRequest::class, false, 'plain array'];
+        yield 'nullable collection item' => [NullableItemCollectionRequest::class, false, 'Nullable collection items'];
+        yield 'unsupported collection item type' => [
+            UnsupportedItemCollectionRequest::class,
+            false,
+            'Unsupported collection item type',
+        ];
+        yield 'split on non-collection' => [SplitOnNonCollectionRequest::class, false, 'requires a scalar collection'];
+        yield 'max items on non-collection' => [
+            MaxItemsOnNonCollectionRequest::class,
+            false,
+            'requires a collection property',
+        ];
+        yield 'max items below one' => [MaxItemsBelowOneRequest::class, false, 'positive item limit'];
+        yield 'split with empty separator' => [SplitEmptySeparatorRequest::class, false, 'empty separator'];
+        yield 'freeform on non-array' => [FreeFormOnNonArrayRequest::class, false, 'requires an array-typed property'];
+        yield 'freeform with item type' => [FreeFormWithItemTypeRequest::class, false, 'combines #[FreeForm]'];
+    }
+
+    private function factory(): PlanFactory
+    {
+        // Ленивое замыкание реестра — как tagged_iterator в контейнере:
+        // NestedObjectCaster зависит от фабрики планов, которая зависит от реестра.
+        $casters = new \ArrayObject();
+        $registry = new CasterRegistry($casters);
+        $factory = new PlanFactory($registry);
+        $assembler = new ObjectAssembler();
+
+        $casters->append(new ScalarCaster());
+        $casters->append(new IntCaster());
+        $casters->append(new BoolCaster());
+        $casters->append(new EnumCaster());
+        $casters->append(new DateCaster());
+        $casters->append(new NestedObjectCaster($factory, $assembler));
+        $casters->append(new CollectionCaster($factory, $assembler));
+        $casters->append(new ScalarCollectionCaster());
+        $casters->append(new FreeFormCaster());
+
+        return $factory;
+    }
+
+    /**
+     * @param list<PropertyPlan> $properties
+     */
+    private function property(array $properties, string $name): PropertyPlan
+    {
+        foreach ($properties as $property) {
+            if ($property->name === $name) {
+                return $property;
+            }
+        }
+
+        throw new \LogicException(sprintf('Property %s not found in plan.', $name));
+    }
+
+    private function unwrap(ValueCaster $decorator): ValueCaster
+    {
+        $property = new \ReflectionProperty($decorator, 'inner');
+
+        /** @var ValueCaster */
+        return $property->getValue($decorator);
+    }
+}

--- a/tests/Unit/Payload/RecordingLogger.php
+++ b/tests/Unit/Payload/RecordingLogger.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Psr\Log\AbstractLogger;
+
+final class RecordingLogger extends AbstractLogger
+{
+    /** @var list<array{level: mixed, message: string, context: array}> */
+    public array $records = [];
+
+    public function log($level, \Stringable|string $message, array $context = []): void
+    {
+        $this->records[] = ['level' => $level, 'message' => (string)$message, 'context' => $context];
+    }
+}

--- a/tests/Unit/Payload/RequestContextTest.php
+++ b/tests/Unit/Payload/RequestContextTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Error\MalformedPayloadException;
+use Leads\Core\Payload\Error\PayloadTooLargeException;
+use Leads\Core\Payload\RequestContext;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RequestContextTest extends TestCase
+{
+    public function testEmptyBodyDecodesToEmptyArray(): void
+    {
+        $context = $this->contextWithBody('');
+
+        $this->assertSame([], $context->body());
+    }
+
+    public function testValidJsonObjectIsDecoded(): void
+    {
+        $context = $this->contextWithBody('{"name": "test", "items": [1, 2]}');
+
+        $this->assertSame(['name' => 'test', 'items' => [1, 2]], $context->body());
+    }
+
+    public function testOversizedBodyIsRejectedBeforeDecode(): void
+    {
+        $context = $this->contextWithBody('{"a":"' . str_repeat('x', 100) . '"}', maxBodyBytes: 50);
+
+        $this->expectException(PayloadTooLargeException::class);
+
+        $context->body();
+    }
+
+    public function testOversizedInvalidJsonStillGives413Not400(): void
+    {
+        $context = $this->contextWithBody(str_repeat('не json', 100), maxBodyBytes: 50);
+
+        $this->expectException(PayloadTooLargeException::class);
+
+        $context->body();
+    }
+
+    public function testMalformedJsonIsRejected(): void
+    {
+        $context = $this->contextWithBody('{"name": broken}');
+
+        $this->expectException(MalformedPayloadException::class);
+
+        $context->body();
+    }
+
+    public function testTooDeepJsonIsRejected(): void
+    {
+        $body = str_repeat('[', 40) . '1' . str_repeat(']', 40);
+        $context = $this->contextWithBody($body);
+
+        $this->expectException(MalformedPayloadException::class);
+
+        $context->body();
+    }
+
+    public function testScalarJsonBodyIsRejected(): void
+    {
+        $context = $this->contextWithBody('42');
+
+        $this->expectException(MalformedPayloadException::class);
+
+        $context->body();
+    }
+
+    public function testQueryAndPathParamsAndHeader(): void
+    {
+        $request = Request::create('/users?limit=10', Request::METHOD_GET);
+        $request->attributes->set('_route_params', ['id' => 'uuid-1']);
+        $request->attributes->set('_route', 'users_list');
+        $request->headers->set('X-Request-Source', 'mobile');
+
+        $context = RequestContext::fromRequest($request, 1024);
+
+        $this->assertSame(['limit' => '10'], $context->query());
+        $this->assertSame(['id' => 'uuid-1'], $context->pathParams());
+        $this->assertSame('mobile', $context->header('X-Request-Source'));
+        $this->assertNull($context->header('X-Missing'));
+        $this->assertSame('users_list', $context->routeName());
+    }
+
+    private function contextWithBody(string $body, int $maxBodyBytes = 1024): RequestContext
+    {
+        $request = Request::create('/users', Request::METHOD_POST, server: [], content: $body);
+
+        return RequestContext::fromRequest($request, $maxBodyBytes);
+    }
+}

--- a/tests/Unit/Payload/Resolver/PayloadValueResolverTest.php
+++ b/tests/Unit/Payload/Resolver/PayloadValueResolverTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Resolver;
+
+use Leads\Core\Payload\Attribute\Payload;
+use Leads\Core\Payload\Cast\BoolCaster;
+use Leads\Core\Payload\Cast\CasterRegistry;
+use Leads\Core\Payload\Cast\DateCaster;
+use Leads\Core\Payload\Cast\EnumCaster;
+use Leads\Core\Payload\Cast\IntCaster;
+use Leads\Core\Payload\Cast\ScalarCaster;
+use Leads\Core\Payload\ObjectAssembler;
+use Leads\Core\Payload\PayloadMapper;
+use Leads\Core\Payload\Plan\PlanFactory;
+use Leads\Core\Payload\Resolver\PayloadValueResolver;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Fixture\Payload\SampleRequest;
+use Leads\Core\Tests\Fixture\Payload\SampleSortField;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+use Symfony\Component\Validator\Validation;
+
+final class PayloadValueResolverTest extends TestCase
+{
+    public function testResolvesDtoForArgumentWithPayloadAttribute(): void
+    {
+        $argument = new ArgumentMetadata(
+            name: 'request',
+            type: SampleRequest::class,
+            isVariadic: false,
+            hasDefaultValue: false,
+            defaultValue: null,
+            isNullable: false,
+            attributes: [new Payload()],
+        );
+
+        $resolved = [...$this->resolver()->resolve(Request::create('/sample?sortBy=LASTNAME'), $argument)];
+
+        $this->assertCount(1, $resolved);
+        $this->assertInstanceOf(SampleRequest::class, $resolved[0]);
+        $this->assertSame(SampleSortField::LastName, $resolved[0]->sortBy);
+    }
+
+    public function testSkipsArgumentWithoutPayloadAttribute(): void
+    {
+        $argument = new ArgumentMetadata(
+            name: 'request',
+            type: SampleRequest::class,
+            isVariadic: false,
+            hasDefaultValue: false,
+            defaultValue: null,
+        );
+
+        $resolved = [...$this->resolver()->resolve(Request::create('/sample'), $argument)];
+
+        $this->assertSame([], $resolved);
+    }
+
+    public function testThrowsOnUntypedArgumentWithPayloadAttribute(): void
+    {
+        $argument = new ArgumentMetadata(
+            name: 'request',
+            type: null,
+            isVariadic: false,
+            hasDefaultValue: false,
+            defaultValue: null,
+            isNullable: false,
+            attributes: [new Payload()],
+        );
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('must be typed');
+
+        [...$this->resolver()->resolve(Request::create('/sample'), $argument)];
+    }
+
+    private function resolver(): PayloadValueResolver
+    {
+        $registry = new CasterRegistry([
+            new ScalarCaster(),
+            new IntCaster(),
+            new BoolCaster(),
+            new EnumCaster(),
+            new DateCaster(),
+        ]);
+
+        $mapper = new PayloadMapper(
+            plans: new PlanFactory($registry),
+            assembler: new ObjectAssembler(),
+            sources: [
+                'body' => new BodySource(),
+                'query' => new QuerySource(),
+                'path' => new PathSource(),
+                'header' => new HeaderSource(),
+            ],
+            validator: Validation::createValidatorBuilder()->enableAttributeMapping()->getValidator(),
+            logger: new NullLogger(),
+        );
+
+        return new PayloadValueResolver($mapper);
+    }
+}

--- a/tests/Unit/Payload/ResultTest.php
+++ b/tests/Unit/Payload/ResultTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload;
+
+use Leads\Core\Payload\Error\Reason;
+use Leads\Core\Payload\Result;
+use PHPUnit\Framework\TestCase;
+
+final class ResultTest extends TestCase
+{
+    public function testOkHoldsValue(): void
+    {
+        $result = Result::ok(42);
+
+        $this->assertTrue($result->isOk());
+        $this->assertSame(42, $result->value());
+        $this->assertSame([], $result->reasons());
+    }
+
+    public function testOkAcceptsNullValue(): void
+    {
+        $result = Result::ok(null);
+
+        $this->assertTrue($result->isOk());
+        $this->assertNull($result->value());
+    }
+
+    public function testFailHoldsReasons(): void
+    {
+        $first = new Reason('type.int', 'Expected an integer.');
+        $second = new Reason('required', 'Required.');
+
+        $result = Result::fail($first, $second);
+
+        $this->assertFalse($result->isOk());
+        $this->assertSame([$first, $second], $result->reasons());
+    }
+
+    public function testValueOnFailedResultThrows(): void
+    {
+        $result = Result::fail(new Reason('type.int', 'Expected an integer.'));
+
+        $this->expectException(\LogicException::class);
+
+        $result->value();
+    }
+}

--- a/tests/Unit/Payload/Source/SourcesTest.php
+++ b/tests/Unit/Payload/Source/SourcesTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Leads\Core\Tests\Unit\Payload\Source;
+
+use Leads\Core\Payload\RequestContext;
+use Leads\Core\Payload\Source\BodySource;
+use Leads\Core\Payload\Source\HeaderSource;
+use Leads\Core\Payload\Source\PathSource;
+use Leads\Core\Payload\Source\QuerySource;
+use Leads\Core\Tests\Builder\PropertyPlanBuilder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class SourcesTest extends TestCase
+{
+    public function testBodySourceDistinguishesAbsentFromNull(): void
+    {
+        $context = $this->context();
+        $present = new PropertyPlanBuilder(key: 'name', sourceKey: 'body')->build();
+        $explicitNull = new PropertyPlanBuilder(key: 'comment', sourceKey: 'body')->build();
+        $absent = new PropertyPlanBuilder(key: 'missing', sourceKey: 'body')->build();
+
+        $source = new BodySource();
+
+        $this->assertTrue($source->has($context, $present));
+        $this->assertSame('john', $source->extract($context, $present));
+        $this->assertTrue($source->has($context, $explicitNull));
+        $this->assertNull($source->extract($context, $explicitNull));
+        $this->assertFalse($source->has($context, $absent));
+    }
+
+    public function testQuerySource(): void
+    {
+        $context = $this->context();
+        $present = new PropertyPlanBuilder(key: 'limit')->build();
+        $absent = new PropertyPlanBuilder(key: 'missing')->build();
+
+        $source = new QuerySource();
+
+        $this->assertTrue($source->has($context, $present));
+        $this->assertSame('10', $source->extract($context, $present));
+        $this->assertFalse($source->has($context, $absent));
+    }
+
+    public function testPathSource(): void
+    {
+        $context = $this->context();
+        $present = new PropertyPlanBuilder(key: 'id', sourceKey: 'path')->build();
+        $absent = new PropertyPlanBuilder(key: 'missing', sourceKey: 'path')->build();
+
+        $source = new PathSource();
+
+        $this->assertTrue($source->has($context, $present));
+        $this->assertSame('uuid-1', $source->extract($context, $present));
+        $this->assertFalse($source->has($context, $absent));
+    }
+
+    public function testHeaderSource(): void
+    {
+        $context = $this->context();
+        $present = new PropertyPlanBuilder(key: 'X-Request-Source', sourceKey: 'header')->build();
+        $absent = new PropertyPlanBuilder(key: 'X-Missing', sourceKey: 'header')->build();
+
+        $source = new HeaderSource();
+
+        $this->assertTrue($source->has($context, $present));
+        $this->assertSame('mobile', $source->extract($context, $present));
+        $this->assertFalse($source->has($context, $absent));
+    }
+
+    public function testSourceKeysAreDistinct(): void
+    {
+        $this->assertSame('body', BodySource::key());
+        $this->assertSame('query', QuerySource::key());
+        $this->assertSame('path', PathSource::key());
+        $this->assertSame('header', HeaderSource::key());
+    }
+
+    private function context(): RequestContext
+    {
+        $request = Request::create(
+            uri: '/users?limit=10',
+            method: Request::METHOD_POST,
+            content: '{"name": "john", "comment": null}',
+        );
+        $request->attributes->set('_route_params', ['id' => 'uuid-1']);
+        $request->headers->set('X-Request-Source', 'mobile');
+
+        return RequestContext::fromRequest($request, 1024);
+    }
+}


### PR DESCRIPTION
Port the Payload module: attribute-declared request DTO mapping (PayloadMapper, plan compilation, casters, sources, RFC 9457 errors, #[Payload] value resolver) with unit and integration tests, PHPUnit infrastructure and bundle DI wiring via autoconfiguration tags. Release 1.2.0.